### PR TITLE
Adding description key for requests.

### DIFF
--- a/lib/converters/converter-v1-to-v2.js
+++ b/lib/converters/converter-v1-to-v2.js
@@ -137,6 +137,16 @@ var _ = require('lodash'),
         },
 
         /**
+         * Constructs a V2 Request compatible "description" from a V1 Postman request
+         *
+         * @param requestV1
+         * @returns {*}
+         */
+        description: function (requestV1) {
+            return requestV1.description;
+        },
+
+        /**
          * Constructs a V2 "events" object from a V1 Postman Request
          *
          * @param requestV1
@@ -176,7 +186,7 @@ var _ = require('lodash'),
          */
         request: _.memoize(function (requestV1) {
             var self = this,
-                units = ['url', 'method', 'headers', 'data', 'events', '_postman_currentHelper',
+                units = ['url', 'method', 'headers', 'data', 'description', 'events', '_postman_currentHelper',
                          '_postman_helperAttributes'],
                 request = {
                     // jscs:disable

--- a/lib/converters/converter-v2-to-v1.js
+++ b/lib/converters/converter-v2-to-v1.js
@@ -78,6 +78,7 @@ var _ = require('lodash'),
                     request = {
                         id: item.request._postman_compat_id,
                         name: item.name,
+                        description: item.description,
                         url: item.request.url.href,
                         collectionId: collectionV2.info.id,
                         method: item.request.method,


### PR DESCRIPTION
 - Description key for requests was not being parsed while converting from v1 to v2 and vice versa. Parsing it now and adding it to all requests.