### PR TITLE
Configurable support for v2 with multifolders. Converts to v1 folders with a .parentId

### DIFF
--- a/examples/v2.1.0/twitter_multifolder.json
+++ b/examples/v2.1.0/twitter_multifolder.json
@@ -8,15 +8,15 @@
     },
     "items": [
         {
-            "name": "User Specific Folder",
+            "name": "User Specific FolderL1",
             "description": "These requests are specific to the user whos auth tokens you have",
             "items": [
                 {
-                    "name": "MentionsFolder",
+                    "name": "MentionsFolderL2",
                     "description": "Second level folder",
                     "items": [
                         {
-                            "name": "MentionsFolder",
+                            "name": "MentionsRequestL2",
                             "request": {
                                 "auth": {
                                     "type": "oauth1",
@@ -40,6 +40,30 @@
                             "responses": []
                         }
                     ]
+                },
+                {
+                    "name": "MentionsRequestL1",
+                    "request": {
+                        "auth": {
+                            "type": "oauth1",
+                            "oauth1": {}
+                        },
+                        "url": "https://api.twitter.com/1.1/statuses/home_timeline.json",
+                        "method": "GET",
+                        "headers": [
+                            {
+                                "key": "Authorization",
+                                "value": "OAuth oauth_consumer_key=\"d2ZxSW0dTPkGuMM9sAIBxWZLw\",oauth_token=\"160113786-lJUEMPzvQ61utoGADZfPKOSsbkKtR6czzuDblvC0\",oauth_signature_method=\"HMAC-SHA1\",oauth_timestamp=\"1434532628\",oauth_nonce=\"HOW7JN\",oauth_version=\"1.0\",oauth_signature=\"h2vIYOZCPOiKVHKuIfQaR1gNUoY%3D\"",
+                                "description": ""
+                            }
+                        ],
+                        "body": {
+                            "mode": "formdata",
+                            "formdata": []
+                        },
+                        "description": ""
+                    },
+                    "responses": []
                 }
             ]
         }

--- a/examples/v2.1.0/twitter_multifolder.json
+++ b/examples/v2.1.0/twitter_multifolder.json
@@ -1,0 +1,47 @@
+{
+    "variables": [],
+    "info": {
+        "name": "TwitterMultiFolder",
+        "_postman_id": "d362bd3b-ab81-2b7d-0ce5-345df1826043",
+        "description": "",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0-draft.1/collection.json"
+    },
+    "items": [
+        {
+            "name": "User Specific Folder",
+            "description": "These requests are specific to the user whos auth tokens you have",
+            "items": [
+                {
+                    "name": "MentionsFolder",
+                    "description": "Second level folder",
+                    "items": [
+                        {
+                            "name": "MentionsFolder",
+                            "request": {
+                                "auth": {
+                                    "type": "oauth1",
+                                    "oauth1": {}
+                                },
+                                "url": "https://api.twitter.com/1.1/statuses/home_timeline.json",
+                                "method": "GET",
+                                "headers": [
+                                    {
+                                        "key": "Authorization",
+                                        "value": "OAuth oauth_consumer_key=\"d2ZxSW0dTPkGuMM9sAIBxWZLw\",oauth_token=\"160113786-lJUEMPzvQ61utoGADZfPKOSsbkKtR6czzuDblvC0\",oauth_signature_method=\"HMAC-SHA1\",oauth_timestamp=\"1434532628\",oauth_nonce=\"HOW7JN\",oauth_version=\"1.0\",oauth_signature=\"h2vIYOZCPOiKVHKuIfQaR1gNUoY%3D\"",
+                                        "description": ""
+                                    }
+                                ],
+                                "body": {
+                                    "mode": "formdata",
+                                    "formdata": []
+                                },
+                                "description": ""
+                            },
+                            "responses": []
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/lib/converters/converter-v2-to-v1.js
+++ b/lib/converters/converter-v2-to-v1.js
@@ -278,23 +278,27 @@ _.extend(Builders.prototype, {
     },
 
     /**
-     * Creates a V1 compatible array of requests from a Postman V2 collection.
+     * Creates a V1 compatible array of requests from a Postman V2 parent item.
      *
-     * @param collectionV2
+     * @param parentItem
      */
     /* jshint ignore:start */ // jscs:disable
-    requests: function (collectionV2) {
+    requests: function (parentItem, collectionId) {
         var self = this,
-            collectionItems = collectionV2.items || collectionV2.item,
-            flattenedItems = _.flatten(_.map(collectionItems, function (item) {
-                var folderItems = item.items || item.item;
-                return (folderItems) ? folderItems : item;
-            })),
+            childItems = parentItem.items || parentItem.item,            
             requests = [];
-        _.each(flattenedItems, function (item) {
+
+        _.each(childItems, function (item) {
             var isFolder = (item.items || item.item);
+
             if (!isFolder) {
-                requests.push(self.request(item, (collectionV2.info.id || collectionV2.info._postman_id)));
+                // it's a request
+                requests.push(self.request(item, collectionId));
+
+            }
+            else if(self.options.flattenMultiFolders === true) {
+                // might have its own requests
+                requests = requests.concat(self.requests(item, collectionId));
             }
         });
         return requests;
@@ -361,8 +365,7 @@ module.exports = {
     Builders: Builders,
 
     convert: function (collection, options, callback) {
-        var units = ['order', 'folders', 'requests'],
-            builders = new Builders(options),
+        var builders = new Builders(options),
             newCollection = {
                 // jscs:disable
                 id: collection.info._postman_id, // jshint ignore:line
@@ -374,9 +377,11 @@ module.exports = {
         // ensure that each item has an ID
         collection = populateIds(collection);
         try {
-            units.map(function (unit) {
-                newCollection[unit] = builders[unit](collection);
-            });
+            // the old method of looping over ['order', 'folder', 'request'] left
+            // no room for customization
+            newCollection.order = builders.order(collection);
+            newCollection.folders = builders.folders(collection);
+            newCollection.requests = builders.requests(collection, collection.info._postman_id);
         }
         catch (e) {
             if (callback) {

--- a/lib/converters/converter-v2-to-v1.js
+++ b/lib/converters/converter-v2-to-v1.js
@@ -292,8 +292,10 @@ _.extend(Builders.prototype, {
             })),
             requests = [];
         _.each(flattenedItems, function (item) {
-            var requestV1 = self.request(item, (collectionV2.info.id || collectionV2.info._postman_id));
-            requests.push(requestV1);
+            var isFolder = (item.items || item.item);
+            if (!isFolder) {
+                requests.push(self.request(item, (collectionV2.info.id || collectionV2.info._postman_id)));
+            }
         });
         return requests;
     },
@@ -316,28 +318,40 @@ _.extend(Builders.prototype, {
     },
 
     /**
-     * Creates an array of V1 compatible folders from a V2 collection
+     * Creates an array of V1 compatible folders from a V2 item
      *
-     * @param collectionV2
+     * @param parentItem
      */
-    folders: function (collectionV2) {
-        var itemArray = collectionV2.items || collectionV2.item;
-        return _.map(_.filter(itemArray, function (element) {
+    folders: function (parentItem, parentId) {
+        var self = this,
+            itemArray = parentItem.items || parentItem.item,
+            retFolders = [];
+
+        _.each(_.filter(itemArray, function (element) {
             var isFolder = (element.items || element.item);
             return !!isFolder;
         }), function (folder) {
-            var folderItems = folder.items || folder.item;
-            return {
-                /* jshint ignore:start */ // jscs:disable
-                id: folder._postman_id || folder.id || util.uid(),
-                /* jshint ignore:end */ // jscs:enable
-                name: folder.name,
-                description: folder.description,
-                order: _.map(folderItems, function (f) {
-                    return f._postman_id || f.id;
-                })
-            };
+            var folderItems = folder.items || folder.item,
+                thisFolder = {
+                    /* jshint ignore:start */ // jscs:disable
+                    id: folder._postman_id || folder.id || util.uid(),
+                    /* jshint ignore:end */ // jscs:enable
+                    name: folder.name,
+                    description: folder.description,
+                    order: _.map(folderItems, function (f) {
+                        return f._postman_id || f.id;
+                    })
+                };
+            if (parentId) {
+                thisFolder.parentId = parentId;
+            }
+            retFolders.push(thisFolder);
+            if (self.options.flattenMultiFolders === true) {
+                retFolders = retFolders.concat(self.folders(folder, thisFolder.id));
+            }
         });
+
+        return retFolders;
     }
 });
 

--- a/tests/unit/converter-v2-to-v1-spec.js
+++ b/tests/unit/converter-v2-to-v1-spec.js
@@ -26,7 +26,7 @@ describe('v2.0.0 ==> v1.0.0', function () {
             });
         });
 
-        it('must create a valid V1 collection with multi-level folder support from twitter_multifolder.json', function (done) {
+        it('must create a valid V1 collection with multi folder support from twitter_multifolder', function (done) {
             converter.convert(samples.twitter_multifolder, {
                 flattenMultiFolders: true
             }, function (err, converted) {

--- a/tests/unit/converter-v2-to-v1-spec.js
+++ b/tests/unit/converter-v2-to-v1-spec.js
@@ -26,7 +26,7 @@ describe('v2.0.0 ==> v1.0.0', function () {
             });
         });
 
-        it('must create a valid V1 collection with multi folder support from twitter_multifolder', function (done) {
+        it('must create a V1 collection with multi folder support from twitter_multifolder', function (done) {
             converter.convert(samples.twitter_multifolder, {
                 flattenMultiFolders: true
             }, function (err, converted) {


### PR DESCRIPTION
For future proofing. We can think about enabling the flag in the app, so that the current apps don't break when we get in multi-folder support in future apps.
