### PR TITLE
Split tests & pre-request scripts by `\n` character for …

### DIFF
--- a/lib/converters/converter-v1-to-v2.js
+++ b/lib/converters/converter-v1-to-v2.js
@@ -186,7 +186,7 @@ _.extend(Builders.prototype, {
                 listen: 'test',
                 script: {
                     type: 'text/javascript',
-                    exec: requestV1.tests
+                    exec: requestV1.tests.split('\n')
                 }
             });
         }
@@ -195,7 +195,7 @@ _.extend(Builders.prototype, {
                 listen: 'prerequest',
                 script: {
                     type: 'text/javascript',
-                    exec: requestV1.preRequestScript
+                    exec: requestV1.preRequestScript.split('\n')
                 }
             });
         }

--- a/lib/converters/converter-v1-to-v2.js
+++ b/lib/converters/converter-v1-to-v2.js
@@ -186,7 +186,9 @@ _.extend(Builders.prototype, {
                 listen: 'test',
                 script: {
                     type: 'text/javascript',
-                    exec: _.isString(requestV1.tests) ? requestV1.tests.split('\n') : requestV1.tests
+                    exec: _.isString(requestV1.tests) ?
+                      requestV1.tests.split('\n') :
+                      requestV1.tests
                 }
             });
         }
@@ -195,7 +197,9 @@ _.extend(Builders.prototype, {
                 listen: 'prerequest',
                 script: {
                     type: 'text/javascript',
-                    exec: _.isString(requestV1.preRequestScript) ? requestV1.preRequestScript.split('\n') : requestV1.preRequestScript
+                    exec: _.isString(requestV1.preRequestScript) ?
+                      requestV1.preRequestScript.split('\n') :
+                      requestV1.preRequestScript
                 }
             });
         }

--- a/lib/converters/converter-v1-to-v2.js
+++ b/lib/converters/converter-v1-to-v2.js
@@ -186,7 +186,7 @@ _.extend(Builders.prototype, {
                 listen: 'test',
                 script: {
                     type: 'text/javascript',
-                    exec: requestV1.tests.split('\n')
+                    exec: _.isString(requestV1.tests) ? requestV1.tests.split('\n') : requestV1.tests
                 }
             });
         }
@@ -195,7 +195,7 @@ _.extend(Builders.prototype, {
                 listen: 'prerequest',
                 script: {
                     type: 'text/javascript',
-                    exec: requestV1.preRequestScript.split('\n')
+                    exec: _.isString(requestV1.preRequestScript) ? requestV1.preRequestScript.split('\n') : requestV1.preRequestScript
                 }
             });
         }


### PR DESCRIPTION
When exporting as a V2 collection, split tests & pre-request scripts by `\n` character for easier debugging