### PR TITLE
Fixed the conversion of v2 to v1 format for description to makesure the value is always string

### DIFF
--- a/examples/v2.1.0/proper-description-parsing.json
+++ b/examples/v2.1.0/proper-description-parsing.json
@@ -1,0 +1,60 @@
+{
+    "variables": [],
+    "info": {
+        "name": "proper-description-parsing",
+        "_postman_id": "7ea31a30-8377-0e56-d11f-5943e6527bca",
+        "description": {
+          "content": "V2 supported collection description in object format",
+          "type": "text/plain"
+        },
+        "schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+    },
+    "item": [
+        {
+            "id": "2c03f359-f259-bb30-d14c-ea278056e95f",
+            "name": "request with hostname as variable",
+            "request": {
+                "url": {
+                    "raw": "https://ani{{yo}}ket:{{asd}}@{{hellohost}}:2002/crazyvar/{{yo}}/:awesome?a=b&c=d#/awesomeshit",
+                    "protocol": "https",
+                    "auth": {
+                        "user": "ani{{yo}}ket",
+                        "password": "{{asd}}"
+                    },
+                    "host": [
+                        "{{hellohost}}"
+                    ],
+                    "port": "2002",
+                    "path": [
+                        "crazyvar",
+                        "{{yo}}",
+                        ":awesome"
+                    ],
+                    "query": [
+                        {
+                            "key": "a",
+                            "value": "b"
+                        },
+                        {
+                            "key": "c",
+                            "value": "d"
+                        }
+                    ],
+                    "hash": "/awesomeshit",
+                    "variable": []
+                },
+                "method": "GET",
+                "header": [],
+                "body": {
+                    "mode": "formdata",
+                    "formdata": []
+                },
+                "description": {
+                  "content": "V2 supported request description in object format",
+                  "type": "text/plain"
+                }
+            },
+            "response": []
+        }
+    ]
+}

--- a/lib/converters/converter-v2-to-v1.js
+++ b/lib/converters/converter-v2-to-v1.js
@@ -281,7 +281,7 @@ _.extend(Builders.prototype, {
             id: item.id || item._postman_id || util.uid(), // jshint ignore:line
             // jscs:enable
             name: item.name,
-            description: item.request && item.request.description,
+            description: item.request && self.description(item.request.description),
             collectionId: collectionId,
             method: item.request ? item.request.method : undefined,
             currentHelper: currentHelper,
@@ -338,7 +338,8 @@ _.extend(Builders.prototype, {
      * @param collectionV2
      */
     folders: function (collectionV2) {
-        var itemArray = collectionV2.items || collectionV2.item;
+        var self = this,
+            itemArray = collectionV2.items || collectionV2.item;
         return _.map(_.filter(itemArray, function (element) {
             var isFolder = (element.items || element.item);
             return !!isFolder;
@@ -347,12 +348,26 @@ _.extend(Builders.prototype, {
             return {
                 id: folder.id || folder._postman_id || util.uid(),
                 name: folder.name,
-                description: folder.description,
+                description: self.description(folder.description),
                 order: _.map(folderItems, function (f) {
                     return f.id || f._postman_id;
                 })
             };
         });
+    },
+
+    /**
+     * Creates the v1 compatable description string from the v2 description format.
+     *
+     * @param descriptionV2
+     *
+     * @returns {String=}
+     */
+    description: function (descriptionV2) {
+        if (_.isObject(descriptionV2) && !_.isEmpty(descriptionV2.content)) {
+            return _.isString(descriptionV2.content) ? descriptionV2.content : '';
+        }
+        return _.isString(descriptionV2) ? descriptionV2 : '';
     }
 });
 
@@ -371,7 +386,7 @@ module.exports = {
                     util.uid(), // jshint ignore:line
                 // jscs:enable
                 name: collection.info.name,
-                description: collection.info.description
+                description: builders.description(collection.info.description)
             };
 
         // ensure that each item has an ID


### PR DESCRIPTION
The previous version of transformer fails in converting the descriptions in the format of 
```
{
 "content": "V2 supported collection description in object format", 
  type": "text/plain"
}
```
The handling has been made now in the collection-v2-v1 convertor