### PR TITLE
Fixed bug in request body file transformations

### DIFF
--- a/lib/converters/converter-v2-to-v1.js
+++ b/lib/converters/converter-v2-to-v1.js
@@ -116,6 +116,11 @@ _.extend(Builders.prototype, {
         return _.map(item.request.body[mode], function (elem) {
             elem = _.clone(elem);
 
+            if (elem && elem.type === 'file' && _.has(elem, 'src')) {
+                elem.value = elem.src;
+                delete elem.src;
+            }
+
             // Prevents empty request body descriptions from showing up in the result, keeps collections clean.
             _.has(elem, 'description') && _.isEmpty(elem.description) && (delete elem.description);
             _.has(elem, 'disabled') && (elem.enabled = !elem.disabled);

--- a/lib/converters/converter-v2-to-v1.js
+++ b/lib/converters/converter-v2-to-v1.js
@@ -116,7 +116,8 @@ _.extend(Builders.prototype, {
         return _.map(item.request.body[mode], function (elem) {
             elem = _.clone(elem);
 
-            if (elem && elem.type === 'file' && _.has(elem, 'src')) {
+            // Only update the value in v1 if src in v2 is non-empty
+            if (elem && elem.type === 'file' && _.has(elem, 'src') && !_.isEmpty(elem.src)) {
                 elem.value = elem.src;
                 delete elem.src;
             }

--- a/tests/unit/converter-v1-to-v2-spec.js
+++ b/tests/unit/converter-v1-to-v2-spec.js
@@ -103,4 +103,25 @@ describe('v1.0.0 to v2.0.0', function () {
             });
         });
     });
+
+    describe('request file body', function () {
+        it('should correctly handle request file bodies whilst converting from v1 to v2', function (done) {
+            var fixture = require('./fixtures/request-body-file'),
+                options = {
+                    inputVersion: '1.0.0',
+                    outputVersion: '2.0.0',
+                    retainIds: true
+                };
+
+            transformer.convert(fixture.v1, options, function (err, converted) {
+                expect(err).to.not.be.ok();
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql(fixture.v2);
+                done();
+            });
+        });
+    });
 });

--- a/tests/unit/converter-v2-to-v1-spec.js
+++ b/tests/unit/converter-v2-to-v1-spec.js
@@ -200,4 +200,25 @@ describe('v2.0.0 to v1.0.0', function () {
             });
         });
     });
+
+    describe('request file body', function () {
+        it('should correctly handle request file bodies whilst converting from v1 to v2', function (done) {
+            var fixture = require('./fixtures/request-body-file'),
+                options = {
+                    inputVersion: '2.0.0',
+                    outputVersion: '1.0.0',
+                    retainIds: true
+                };
+
+            transformer.convert(fixture.v2, options, function (err, converted) {
+                expect(err).to.not.be.ok();
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql(fixture.v1);
+                done();
+            });
+        });
+    });
 });

--- a/tests/unit/converter-v2-to-v1-spec.js
+++ b/tests/unit/converter-v2-to-v1-spec.js
@@ -202,7 +202,7 @@ describe('v2.0.0 to v1.0.0', function () {
     });
 
     describe('request file body', function () {
-        it('should correctly handle request file bodies whilst converting from v1 to v2', function (done) {
+        it('should correctly handle request file bodies whilst converting from v2 to v1', function (done) {
             var fixture = require('./fixtures/request-body-file'),
                 options = {
                     inputVersion: '2.0.0',

--- a/tests/unit/fixtures/request-body-file.js
+++ b/tests/unit/fixtures/request-body-file.js
@@ -1,0 +1,98 @@
+module.exports = {
+    v1: {
+        id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+        name: 'body-src-check',
+        order: [
+            '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+            '3d2c6dbc-cefa-0951-2796-3f0142ff85c3'
+        ],
+        folders: [],
+        folders_order: [],
+        requests: [
+            {
+                id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                headers: '',
+                headerData: [],
+                url: 'https://postman-echo.com/post',
+                queryParams: [],
+                pathVariableData: [],
+                method: 'POST',
+                rawModeData: '',
+                data: [
+                    {
+                        key: 'file',
+                        value: 't.csv',
+                        description: 'Enabled CSV file',
+                        type: 'file'
+                    }
+                ],
+                dataMode: 'params',
+                name: 'Formdata POST',
+                collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                responses: []
+            },
+            {
+                id: '3d2c6dbc-cefa-0951-2796-3f0142ff85c3',
+                headers: '',
+                headerData: [],
+                url: 'https://postman-echo.com/post',
+                queryParams: [],
+                pathVariableData: [],
+                method: 'POST',
+                data: [],
+                dataMode: 'binary',
+                name: 'Binary POST',
+                collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                responses: [],
+                rawModeData: 't.csv'
+            }
+        ]
+    },
+    v2: {
+        variables: [],
+        info: {
+            name: 'body-src-check',
+            _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+            schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+        },
+        item: [
+            {
+                _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                name: 'Formdata POST',
+                request: {
+                    url: 'https://postman-echo.com/post',
+                    method: 'POST',
+                    header: [],
+                    body: {
+                        mode: 'formdata',
+                        formdata: [
+                            {
+                                key: 'file',
+                                description: 'Enabled CSV file',
+                                type: 'file',
+                                src: 't.csv'
+                            }
+                        ]
+                    }
+                },
+                response: []
+            },
+            {
+                _postman_id: '3d2c6dbc-cefa-0951-2796-3f0142ff85c3',
+                name: 'Binary POST',
+                request: {
+                    url: 'https://postman-echo.com/post',
+                    method: 'POST',
+                    header: [],
+                    body: {
+                        mode: 'file',
+                        file: {
+                            src: 't.csv'
+                        }
+                    }
+                },
+                response: []
+            }
+        ]
+    }
+};


### PR DESCRIPTION
* The V1 schema specifies `value` as the placeholder for both: `text` as well as `file` request body entities.
* The V2 schema specifies `src` for `file`s instead.
* This pull request ensures that `src` is replaced by `value` for V2 to V1 transformations.
* Unit tests included.