### PR TITLE
Inherited transformation/normalization precedence fix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
     "getter-return": "error",
     "no-await-in-loop": "error",
     "no-compare-neg-zero": "error",
-    "no-cond-assign": "error",
+    "no-cond-assign": "off",
     "no-console": "off",
     "no-constant-condition": "error",
     "no-control-regex": "error",

--- a/lib/converters/v1.0.0/converter-v1-to-v2.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v2.js
@@ -213,7 +213,7 @@ _.assign(Builders.prototype, {
         if (!entityV1) { return; }
 
         // events is treated as the source of truth in v1, so handle that first and bail out.
-        if (util.notLegacy(entityV1, 'script') && _.isArray(entityV1.events)) {
+        if (util.notLegacy(entityV1, 'event') && _.isArray(entityV1.events)) {
             // in v1, `events` is regarded as the source of truth if it exists, so handle that first and bail out.
             // @todo: Improve this to order prerequest events before test events
             _.forEach(entityV1.events, function (event) {

--- a/lib/converters/v1.0.0/converter-v1-to-v2.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v2.js
@@ -210,8 +210,10 @@ _.assign(Builders.prototype, {
      * @returns {Array}
      */
     event: function (entityV1) {
+        if (!entityV1) { return; }
+
         // events is treated as the source of truth in v1, so handle that first and bail out.
-        if (_.isArray(entityV1.events)) {
+        if (util.notLegacy(entityV1, 'script') && _.isArray(entityV1.events)) {
             // in v1, `events` is regarded as the source of truth if it exists, so handle that first and bail out.
             // @todo: Improve this to order prerequest events before test events
             _.forEach(entityV1.events, function (event) {
@@ -263,7 +265,8 @@ _.assign(Builders.prototype, {
      * @returns {{type: *}}
      */
     auth: function (entityV1) {
-        if (entityV1 && entityV1.auth) { return util.authArrayToMap(entityV1); }
+        if (!entityV1) { return; }
+        if (util.notLegacy(entityV1, 'auth') && entityV1.auth) { return util.authArrayToMap(entityV1); }
         if ((entityV1.currentHelper === 'normal') || (!entityV1.currentHelper)) {
             return;
         }

--- a/lib/converters/v1.0.0/converter-v1-to-v21.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v21.js
@@ -48,7 +48,7 @@ _.assign(Builders.prototype, {
      */
     auth: function (entityV1) {
         // if the current auth manifest is at a parent level, no further transformation is needed.
-        if (entityV1 && entityV1.auth) { return util.sanitizeAuthArray(entityV1); }
+        if (util.notLegacy(entityV1, 'auth') && entityV1.currentHelper) { return util.sanitizeAuthArray(entityV1); }
 
         var auth = Builders.super_.prototype.auth.call(this, entityV1);
 

--- a/lib/normalizers/v1.js
+++ b/lib/normalizers/v1.js
@@ -1,5 +1,6 @@
 var _ = require('lodash').noConflict(),
     v1Common = require('../common/v1'),
+    v2Common = require('../common/v2'),
     util = require('../util'),
     url = require('../url'),
 
@@ -35,22 +36,22 @@ _.assign(Builders.prototype, {
     /**
      * Normalizes inherited v1 auth manifests.
      *
-     * @param {Object} entity - A v1 compliant wrapped auth manifest.
+     * @param {Object} entityV1 - A v1 compliant wrapped auth manifest.
      * @returns {Object} - A v1 compliant set of auth helper attributes.
      */
-    auth: function (entity) {
-        if (!entity) { return; }
-        if (entity.auth) {
-            if (entity.auth.type === 'noauth') { return; }
+    auth: function (entityV1) {
+        if (!entityV1) { return; }
+        if (util.notLegacy(entityV1, 'auth') && entityV1.auth) {
+            if (entityV1.auth.type === 'noauth') { return; }
 
-            return util.sanitizeAuthArray(entity);
+            return util.sanitizeAuthArray(entityV1);
         }
-        if (!entity.currentHelper || (entity.currentHelper === 'normal')) { return; }
+        if (!entityV1.currentHelper || (entityV1.currentHelper === 'normal')) { return; }
 
-        var auth = { type: v1Common.authMap[entity.currentHelper] };
+        var auth = { type: v1Common.authMap[entityV1.currentHelper] };
 
         // eslint-disable-next-line max-len
-        auth[auth.type] = util.authMappersFromLegacy[entity.currentHelper](entity.helperAttributes);
+        auth[auth.type] = util.authMappersFromLegacy[entityV1.currentHelper](entityV1.helperAttributes);
 
         return util.authMapToArray({ auth: auth });
     },
@@ -62,7 +63,7 @@ _.assign(Builders.prototype, {
      * @returns {Array} - The normalized events.
      */
     events: function (entityV1) {
-        if (_.isArray(entityV1 && entityV1.events)) {
+        if (util.notLegacy(entityV1, 'script') && _.isArray(entityV1 && entityV1.events)) {
             // @todo: Improve this to order prerequest events before test events
             _.forEach(entityV1.events, function (event) {
                 !event.listen && (event.listen = 'test');
@@ -164,8 +165,10 @@ _.assign(Builders.prototype, {
     request: function (requestV1, collectionId, skipResponses) {
         if (!requestV1) { return; }
 
-        var auth,
+        var map,
+            auth,
             events,
+            mapper,
             variables,
             self = this,
             units = ['queryParams', 'pathVariableData', 'headerData', 'data'];
@@ -189,6 +192,27 @@ _.assign(Builders.prototype, {
         (auth = self.auth(requestV1)) ? (requestV1.auth = auth) : (delete requestV1.auth);
         (events = self.events(requestV1)) ? (requestV1.events = events) : (delete requestV1.events);
         (variables = util.handleVars(requestV1)) ? (requestV1.variables = variables) : (delete requestV1.variables);
+
+        if (requestV1.auth && util.notLegacy(requestV1, 'auth')) {
+            requestV1.currentHelper = v2Common.authMap[requestV1.auth.type];
+            if (mapper = util.authMappersFromCurrent[requestV1.currentHelper]) {
+                map = util.authArrayToMap(requestV1);
+                map && (requestV1.helperAttributes = mapper(map[requestV1.auth.type]));
+            }
+        }
+        if (requestV1.events && util.notLegacy(requestV1, 'script')) {
+            requestV1.preRequestScript = '';
+            requestV1.tests = '';
+
+            _.forEach(requestV1.events, function (event) {
+                if (event.listen === 'prerequest') {
+                    requestV1.preRequestScript += event.script.exec.join('\n');
+                }
+                else if (event.listen === 'test') {
+                    requestV1.tests += event.script.exec.join('\n');
+                }
+            });
+        }
 
         return requestV1;
     },

--- a/lib/normalizers/v1.js
+++ b/lib/normalizers/v1.js
@@ -63,7 +63,7 @@ _.assign(Builders.prototype, {
      * @returns {Array} - The normalized events.
      */
     events: function (entityV1) {
-        if (util.notLegacy(entityV1, 'script') && _.isArray(entityV1 && entityV1.events)) {
+        if (util.notLegacy(entityV1, 'event') && _.isArray(entityV1 && entityV1.events)) {
             // @todo: Improve this to order prerequest events before test events
             _.forEach(entityV1.events, function (event) {
                 !event.listen && (event.listen = 'test');
@@ -200,7 +200,7 @@ _.assign(Builders.prototype, {
                 map && (requestV1.helperAttributes = mapper(map[requestV1.auth.type]));
             }
         }
-        if (requestV1.events && util.notLegacy(requestV1, 'script')) {
+        if (requestV1.events && util.notLegacy(requestV1, 'event')) {
             requestV1.preRequestScript = '';
             requestV1.tests = '';
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -160,10 +160,10 @@ util = {
         if (!entityV1) { return; }
 
         switch (type) {
-            case 'script':
+            case 'event':
                 return !(entityV1.tests || entityV1.preRequestScript);
             case 'auth':
-                return !entityV1.currentHelper || _.isEmpty(entityV1.helperAttributes);
+                return !(entityV1.currentHelper && entityV1.helperAttributes);
             default:
                 return true;
         }

--- a/lib/util.js
+++ b/lib/util.js
@@ -148,6 +148,27 @@ util = {
         return result;
     },
 
+    /**
+     * A helper function to determine if the provided v1 entity has legacy properties.
+     *
+     * @private
+     * @param {Object} entityV1 - The v1 entity to be checked for the presence of legacy properties.
+     * @param {String} type - The type of property to be adjudged against.
+     * @returns {Boolean} - A flag to indicate the legacy property status of the passed v1 entity.
+     */
+    notLegacy: function (entityV1, type) {
+        if (!entityV1) { return; }
+
+        switch (type) {
+            case 'script':
+                return !(entityV1.tests || entityV1.preRequestScript);
+            case 'auth':
+                return !entityV1.currentHelper || _.isEmpty(entityV1.helperAttributes);
+            default:
+                return true;
+        }
+    },
+
     authMappersFromLegacy: {
         basicAuth: function (oldParams) {
             return {

--- a/npm/test-unit.js
+++ b/npm/test-unit.js
@@ -28,7 +28,7 @@ module.exports = function (exit) {
 
     var Mocha = require('mocha'),
         nyc = new NYC({
-            reporter: ['text'],
+            reporter: ['text', 'lcov'],
             reportDir: COV_REPORT_PATH,
             tempDirectory: COV_REPORT_PATH
         });

--- a/test/unit/fixtures/nested-entities.js
+++ b/test/unit/fixtures/nested-entities.js
@@ -204,6 +204,16 @@ module.exports = {
                             key: 'password',
                             value: '{{token}}',
                             type: 'string'
+                        },
+                        {
+                            key: 'saveHelperData',
+                            value: true,
+                            type: 'boolean'
+                        },
+                        {
+                            key: 'showPassword',
+                            value: false,
+                            type: 'boolean'
                         }
                     ]
                 },
@@ -211,6 +221,7 @@ module.exports = {
                 helperAttributes: {
                     id: 'basic',
                     username: '{{username}}',
+                    saveToRequest: true,
                     password: '{{token}}'
                 },
                 name: 'Basic',
@@ -304,14 +315,32 @@ module.exports = {
                             key: 'realm',
                             value: '',
                             type: 'string'
+                        },
+                        {
+                            key: 'addParamsToHeader',
+                            value: true,
+                            type: 'boolean'
+                        },
+                        {
+                            key: 'autoAddParam',
+                            value: true,
+                            type: 'boolean'
+                        },
+                        {
+                            key: 'addEmptyParamsToSign',
+                            value: false,
+                            type: 'boolean'
                         }
                     ]
                 },
                 currentHelper: 'oAuth1',
                 helperAttributes: {
                     id: 'oAuth1',
+                    auto: true,
+                    includeEmpty: false,
                     consumerKey: 'RKCGzna7bv9YD57c',
                     consumerSecret: 'D+EdQ-gs$-%@2Nu7',
+                    header: true,
                     token: '',
                     tokenSecret: '',
                     signatureMethod: 'HMAC-SHA1',
@@ -452,7 +481,9 @@ module.exports = {
                                 type: 'basic',
                                 basic: {
                                     username: '{{username}}',
-                                    password: '{{token}}'
+                                    password: '{{token}}',
+                                    saveHelperData: true,
+                                    showPassword: false
                                 }
                             },
                             method: 'GET',
@@ -509,7 +540,10 @@ module.exports = {
                             timestamp: '1500452534',
                             nonce: 'S0kXloMHurS',
                             version: '1.0',
-                            realm: ''
+                            realm: '',
+                            addParamsToHeader: true,
+                            autoAddParam: true,
+                            addEmptyParamsToSign: false
                         }
                     },
                     method: 'GET',
@@ -718,6 +752,16 @@ module.exports = {
                                         key: 'password',
                                         value: '{{token}}',
                                         type: 'string'
+                                    },
+                                    {
+                                        key: 'saveHelperData',
+                                        value: true,
+                                        type: 'boolean'
+                                    },
+                                    {
+                                        key: 'showPassword',
+                                        value: false,
+                                        type: 'boolean'
                                     }
                                 ]
                             },
@@ -816,6 +860,21 @@ module.exports = {
                                 key: 'realm',
                                 value: '',
                                 type: 'string'
+                            },
+                            {
+                                key: 'addParamsToHeader',
+                                value: true,
+                                type: 'boolean'
+                            },
+                            {
+                                key: 'autoAddParam',
+                                value: true,
+                                type: 'boolean'
+                            },
+                            {
+                                key: 'addEmptyParamsToSign',
+                                value: false,
+                                type: 'boolean'
                             }
                         ]
                     },

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -144,6 +144,80 @@ describe('v1.0.0 to v2.0.0', function () {
                 done();
             });
         });
+
+        it('should override auth with legacy attributes if they exist', function (done) {
+            var options = {
+                    inputVersion: '1.0.0',
+                    outputVersion: '2.0.0',
+                    retainIds: true
+                },
+                source = {
+                    currentHelper: 'basicAuth',
+                    helperAttributes: {
+                        id: 'basic',
+                        username: 'username',
+                        password: 'password'
+                    },
+                    auth: {
+                        type: 'noauth'
+                    }
+                };
+
+            transformer.convertSingle(source, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted.request.auth).to.eql({
+                    type: 'basic',
+                    basic: {
+                        username: 'username',
+                        password: 'password',
+                        showPassword: false
+                    }
+                });
+                done();
+            });
+        });
+
+        it('should use auth if legacy auth attributes are absent', function (done) {
+            var options = {
+                    inputVersion: '1.0.0',
+                    outputVersion: '2.0.0',
+                    retainIds: true
+                },
+                source = {
+                    auth: {
+                        type: 'basic',
+                        basic: [{
+                            key: 'username',
+                            value: 'username',
+                            type: 'string'
+                        }, {
+                            key: 'password',
+                            value: 'password',
+                            type: 'string'
+                        }]
+                    }
+                };
+
+            transformer.convertSingle(source, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted.request.auth).to.eql({
+                    type: 'basic',
+                    basic: {
+                        username: 'username',
+                        password: 'password'
+                    }
+                });
+                done();
+            });
+        });
     });
 
     describe('nested entities', function () {
@@ -162,6 +236,100 @@ describe('v1.0.0 to v2.0.0', function () {
                 converted = JSON.parse(JSON.stringify(converted));
 
                 expect(converted).to.eql(fixture.v2);
+                done();
+            });
+        });
+    });
+
+    describe('scripts', function () {
+        it('should override events with legacy properties if they exist', function (done) {
+            var options = {
+                    inputVersion: '1.0.0',
+                    outputVersion: '2.0.0',
+                    retainIds: true
+                },
+                source = {
+                    preRequestScript: 'console.log("Request level pre-request script");',
+                    tests: 'console.log("Request level test script");',
+                    events: [{
+                        listen: 'prerequest',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Alternative request level pre-request script");']
+                        }
+                    }, {
+                        listen: 'test',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Alternative request level test script");']
+                        }
+                    }]
+                };
+
+            transformer.convertSingle(source, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted.event).to.eql([{
+                    listen: 'test',
+                    script: {
+                        type: 'text/javascript',
+                        exec: ['console.log("Request level test script");']
+                    }
+                }, {
+                    listen: 'prerequest',
+                    script: {
+                        type: 'text/javascript',
+                        exec: ['console.log("Request level pre-request script");']
+                    }
+                }]);
+                done();
+            });
+        });
+
+        it('should use events if legacy properties are absent', function (done) {
+            var options = {
+                    inputVersion: '1.0.0',
+                    outputVersion: '2.0.0',
+                    retainIds: true
+                },
+                source = {
+                    events: [{
+                        listen: 'prerequest',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Alternative request level pre-request script");']
+                        }
+                    }, {
+                        listen: 'test',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Alternative request level test script");']
+                        }
+                    }]
+                };
+
+            transformer.convertSingle(source, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted.event).to.eql([{
+                    listen: 'prerequest',
+                    script: {
+                        type: 'text/javascript',
+                        exec: ['console.log("Alternative request level pre-request script");']
+                    }
+                }, {
+                    listen: 'test',
+                    script: {
+                        type: 'text/javascript',
+                        exec: ['console.log("Alternative request level test script");']
+                    }
+                }]);
                 done();
             });
         });

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -159,7 +159,8 @@ describe('v1.0.0 to v2.0.0', function () {
                         password: 'password'
                     },
                     auth: {
-                        type: 'noauth'
+                        type: 'bearer',
+                        bearer: [{key: 'token', value: 'randomSecretString', type: 'string'}]
                     }
                 };
 
@@ -169,13 +170,24 @@ describe('v1.0.0 to v2.0.0', function () {
                 // remove `undefined` properties for testing
                 converted = JSON.parse(JSON.stringify(converted));
 
-                expect(converted.request.auth).to.eql({
-                    type: 'basic',
-                    basic: {
-                        username: 'username',
-                        password: 'password',
-                        showPassword: false
-                    }
+                expect(converted).to.eql({
+                    name: '',
+                    request: {
+                        auth: {
+                            type: 'basic',
+                            basic: {
+                                username: 'username',
+                                password: 'password',
+                                showPassword: false
+                            }
+                        },
+                        body: {
+                            mode: 'raw',
+                            raw: ''
+                        },
+                        header: []
+                    },
+                    response: []
                 });
                 done();
             });
@@ -208,12 +220,23 @@ describe('v1.0.0 to v2.0.0', function () {
                 // remove `undefined` properties for testing
                 converted = JSON.parse(JSON.stringify(converted));
 
-                expect(converted.request.auth).to.eql({
-                    type: 'basic',
-                    basic: {
-                        username: 'username',
-                        password: 'password'
-                    }
+                expect(converted).to.eql({
+                    name: '',
+                    request: {
+                        auth: {
+                            type: 'basic',
+                            basic: {
+                                username: 'username',
+                                password: 'password'
+                            }
+                        },
+                        body: {
+                            mode: 'raw',
+                            raw: ''
+                        },
+                        header: []
+                    },
+                    response: []
                 });
                 done();
             });
@@ -272,19 +295,30 @@ describe('v1.0.0 to v2.0.0', function () {
                 // remove `undefined` properties for testing
                 converted = JSON.parse(JSON.stringify(converted));
 
-                expect(converted.event).to.eql([{
-                    listen: 'test',
-                    script: {
-                        type: 'text/javascript',
-                        exec: ['console.log("Request level test script");']
-                    }
-                }, {
-                    listen: 'prerequest',
-                    script: {
-                        type: 'text/javascript',
-                        exec: ['console.log("Request level pre-request script");']
-                    }
-                }]);
+                expect(converted).to.eql({
+                    name: '',
+                    event: [{
+                        listen: 'test',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Request level test script");']
+                        }
+                    }, {
+                        listen: 'prerequest',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Request level pre-request script");']
+                        }
+                    }],
+                    request: {
+                        body: {
+                            mode: 'raw',
+                            raw: ''
+                        },
+                        header: []
+                    },
+                    response: []
+                });
                 done();
             });
         });
@@ -317,19 +351,30 @@ describe('v1.0.0 to v2.0.0', function () {
                 // remove `undefined` properties for testing
                 converted = JSON.parse(JSON.stringify(converted));
 
-                expect(converted.event).to.eql([{
-                    listen: 'prerequest',
-                    script: {
-                        type: 'text/javascript',
-                        exec: ['console.log("Alternative request level pre-request script");']
-                    }
-                }, {
-                    listen: 'test',
-                    script: {
-                        type: 'text/javascript',
-                        exec: ['console.log("Alternative request level test script");']
-                    }
-                }]);
+                expect(converted).to.eql({
+                    name: '',
+                    event: [{
+                        listen: 'prerequest',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Alternative request level pre-request script");']
+                        }
+                    }, {
+                        listen: 'test',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Alternative request level test script");']
+                        }
+                    }],
+                    request: {
+                        body: {
+                            mode: 'raw',
+                            raw: ''
+                        },
+                        header: []
+                    },
+                    response: []
+                });
                 done();
             });
         });

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -144,6 +144,104 @@ describe('v1.0.0 to v2.1.0', function () {
                 done();
             });
         });
+
+        it('should override auth with legacy attributes if they exist', function (done) {
+            var options = {
+                    inputVersion: '1.0.0',
+                    outputVersion: '2.1.0',
+                    retainIds: true
+                },
+                source = {
+                    currentHelper: 'basicAuth',
+                    helperAttributes: {
+                        id: 'basic',
+                        username: 'username',
+                        password: 'password'
+                    },
+                    auth: {
+                        type: 'bearer',
+                        bearer: [{key: 'token', value: 'randomSecretString', type: 'string'}]
+                    }
+                };
+
+            transformer.convertSingle(source, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql({
+                    name: '',
+                    request: {
+                        auth: {
+                            type: 'basic',
+                            basic: [
+                                { key: 'username', value: 'username', type: 'string' },
+                                { key: 'password', value: 'password', type: 'string' },
+                                { key: 'saveHelperData', type: 'any' },
+                                { key: 'showPassword', value: false, type: 'boolean' }
+                            ]
+                        },
+                        body: {
+                            mode: 'raw',
+                            raw: ''
+                        },
+                        header: []
+                    },
+                    response: []
+                });
+                done();
+            });
+        });
+
+        it('should use auth if legacy auth attributes are absent', function (done) {
+            var options = {
+                    inputVersion: '1.0.0',
+                    outputVersion: '2.1.0',
+                    retainIds: true
+                },
+                source = {
+                    auth: {
+                        type: 'basic',
+                        basic: [{
+                            key: 'username',
+                            value: 'username',
+                            type: 'string'
+                        }, {
+                            key: 'password',
+                            value: 'password',
+                            type: 'string'
+                        }]
+                    }
+                };
+
+            transformer.convertSingle(source, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql({
+                    name: '',
+                    request: {
+                        auth: {
+                            type: 'basic',
+                            basic: [
+                                { key: 'username', value: 'username', type: 'string' },
+                                { key: 'password', value: 'password', type: 'string' }
+                            ]
+                        },
+                        body: {
+                            mode: 'raw',
+                            raw: ''
+                        },
+                        header: []
+                    },
+                    response: []
+                });
+                done();
+            });
+        });
     });
 
     describe('nested entities', function () {
@@ -162,6 +260,122 @@ describe('v1.0.0 to v2.1.0', function () {
                 converted = JSON.parse(JSON.stringify(converted));
 
                 expect(converted).to.eql(fixture.v21);
+                done();
+            });
+        });
+    });
+
+    describe('scripts', function () {
+        it('should override events with legacy properties if they exist', function (done) {
+            var options = {
+                    inputVersion: '1.0.0',
+                    outputVersion: '2.1.0',
+                    retainIds: true
+                },
+                source = {
+                    preRequestScript: 'console.log("Request level pre-request script");',
+                    tests: 'console.log("Request level test script");',
+                    events: [{
+                        listen: 'prerequest',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Alternative request level pre-request script");']
+                        }
+                    }, {
+                        listen: 'test',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Alternative request level test script");']
+                        }
+                    }]
+                };
+
+            transformer.convertSingle(source, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql({
+                    name: '',
+                    event: [{
+                        listen: 'test',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Request level test script");']
+                        }
+                    }, {
+                        listen: 'prerequest',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Request level pre-request script");']
+                        }
+                    }],
+                    request: {
+                        body: {
+                            mode: 'raw',
+                            raw: ''
+                        },
+                        header: []
+                    },
+                    response: []
+                });
+                done();
+            });
+        });
+
+        it('should use events if legacy properties are absent', function (done) {
+            var options = {
+                    inputVersion: '1.0.0',
+                    outputVersion: '2.1.0',
+                    retainIds: true
+                },
+                source = {
+                    events: [{
+                        listen: 'prerequest',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Alternative request level pre-request script");']
+                        }
+                    }, {
+                        listen: 'test',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Alternative request level test script");']
+                        }
+                    }]
+                };
+
+            transformer.convertSingle(source, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql({
+                    name: '',
+                    event: [{
+                        listen: 'prerequest',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Alternative request level pre-request script");']
+                        }
+                    }, {
+                        listen: 'test',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Alternative request level test script");']
+                        }
+                    }],
+                    request: {
+                        body: {
+                            mode: 'raw',
+                            raw: ''
+                        },
+                        header: []
+                    },
+                    response: []
+                });
                 done();
             });
         });

--- a/test/unit/v1.0.0/normalize-v1.test.js
+++ b/test/unit/v1.0.0/normalize-v1.test.js
@@ -91,7 +91,8 @@ describe('v1.0.0 normalization', function () {
                             password: 'password'
                         },
                         auth: {
-                            type: 'noauth'
+                            type: 'bearer',
+                            bearer: [{key: 'token', value: 'randomSecretString', type: 'string'}]
                         }
                     };
 

--- a/test/unit/v1.0.0/normalize-v1.test.js
+++ b/test/unit/v1.0.0/normalize-v1.test.js
@@ -27,13 +27,13 @@ describe('v1.0.0 normalization', function () {
                     retainIds: true
                 };
 
-            transformer.normalizeSingle(fixture.raw, options, function (err, converted) {
+            transformer.normalizeSingle(fixture.raw, options, function (err, normalized) {
                 expect(err).to.not.be.ok;
 
                 // remove `undefined` properties for testing
-                converted = JSON.parse(JSON.stringify(converted));
+                normalized = JSON.parse(JSON.stringify(normalized));
 
-                expect(converted).to.eql(fixture.normalized);
+                expect(normalized).to.eql(fixture.normalized);
                 done();
             });
         });
@@ -45,13 +45,13 @@ describe('v1.0.0 normalization', function () {
                     retainIds: true
                 };
 
-            transformer.normalizeResponse(fixture.raw, options, function (err, converted) {
+            transformer.normalizeResponse(fixture.raw, options, function (err, normalized) {
                 expect(err).to.not.be.ok;
 
                 // remove `undefined` properties for testing
-                converted = JSON.parse(JSON.stringify(converted));
+                normalized = JSON.parse(JSON.stringify(normalized));
 
-                expect(converted).to.eql(fixture.normalized);
+                expect(normalized).to.eql(fixture.normalized);
                 done();
             });
         });
@@ -63,14 +63,214 @@ describe('v1.0.0 normalization', function () {
                     retainIds: true
                 };
 
-            transformer.normalize(fixture.raw, options, function (err, converted) {
+            transformer.normalize(fixture.raw, options, function (err, normalized) {
                 expect(err).to.not.be.ok;
 
                 // remove `undefined` properties for testing
-                converted = JSON.parse(JSON.stringify(converted));
+                normalized = JSON.parse(JSON.stringify(normalized));
 
-                expect(converted).to.eql(fixture.normalized);
+                expect(normalized).to.eql(fixture.normalized);
                 done();
+            });
+        });
+    });
+
+    describe('special cases', function () {
+        describe('auth', function () {
+            it('should override auth with legacy properties if both are present', function (done) {
+                var options = {
+                        normalizeVersion: '1.0.0',
+                        retainIds: true
+                    },
+                    source = {
+                        id: 'bd79f978-d862-49f1-9cea-7c71a762cc12',
+                        currentHelper: 'basicAuth',
+                        helperAttributes: {
+                            id: 'basic',
+                            username: 'username',
+                            password: 'password'
+                        },
+                        auth: {
+                            type: 'noauth'
+                        }
+                    };
+
+                transformer.normalizeSingle(source, options, function (err, normalized) {
+                    expect(err).to.not.be.ok;
+
+                    // remove `undefined` properties for testing
+                    normalized = JSON.parse(JSON.stringify(normalized));
+
+                    expect(normalized).to.eql({
+                        id: 'bd79f978-d862-49f1-9cea-7c71a762cc12',
+                        data: [],
+                        currentHelper: 'basicAuth',
+                        helperAttributes: {
+                            id: 'basic',
+                            username: 'username',
+                            password: 'password'
+                        },
+                        auth: {
+                            type: 'basic',
+                            basic: [
+                                {key: 'username', value: 'username', type: 'string'},
+                                {key: 'password', value: 'password', type: 'string'},
+                                {key: 'saveHelperData', type: 'any'},
+                                {key: 'showPassword', value: false, type: 'boolean'}
+                            ]
+                        }
+                    });
+                    done();
+                });
+            });
+
+            it('should fall back to auth if legacy properties are absent', function (done) {
+                var options = {
+                        normalizeVersion: '1.0.0',
+                        retainIds: true
+                    },
+                    source = {
+                        id: '722795b9-c9bc-4a01-a024-dd9358548dc1',
+                        auth: {
+                            type: 'basic',
+                            basic: [
+                                {key: 'username', value: 'username', type: 'string'},
+                                {key: 'password', value: 'password', type: 'string'}
+                            ]
+                        }
+                    };
+
+                transformer.normalizeSingle(source, options, function (err, normalized) {
+                    expect(err).to.not.be.ok;
+
+                    // remove `undefined` properties for testing
+                    normalized = JSON.parse(JSON.stringify(normalized));
+
+                    expect(normalized).to.eql({
+                        id: '722795b9-c9bc-4a01-a024-dd9358548dc1',
+                        data: [],
+                        currentHelper: 'basicAuth',
+                        helperAttributes: {
+                            id: 'basic',
+                            username: 'username',
+                            password: 'password'
+                        },
+                        auth: {
+                            type: 'basic',
+                            basic: [
+                                {key: 'username', value: 'username', type: 'string'},
+                                {key: 'password', value: 'password', type: 'string'}
+                            ]
+                        }
+                    });
+                    done();
+                });
+            });
+        });
+
+        describe('scripts', function () {
+            it('should override events with legacy properties if they exist', function (done) {
+                var options = {
+                        normalizeVersion: '1.0.0',
+                        retainIds: true
+                    },
+                    source = {
+                        id: '95df70cd-8631-4459-bc42-3830f30ecae0',
+                        preRequestScript: 'console.log("Request level pre-request script");',
+                        tests: 'console.log("Request level test script");',
+                        events: [{
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Alternative request level pre-request script");']
+                            }
+                        }, {
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Alternative request level test script");']
+                            }
+                        }]
+                    };
+
+                transformer.normalizeSingle(source, options, function (err, normalized) {
+                    expect(err).to.not.be.ok;
+
+                    // remove `undefined` properties for testing
+                    normalized = JSON.parse(JSON.stringify(normalized));
+
+                    expect(normalized).to.eql({
+                        id: '95df70cd-8631-4459-bc42-3830f30ecae0',
+                        data: [],
+                        preRequestScript: 'console.log("Request level pre-request script");',
+                        tests: 'console.log("Request level test script");',
+                        events: [{
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Request level pre-request script");']
+                            }
+                        }, {
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Request level test script");']
+                            }
+                        }]
+                    });
+                    done();
+                });
+            });
+
+            it('should use events if legacy properties are absent', function (done) {
+                var options = {
+                        normalizeVersion: '1.0.0',
+                        retainIds: true
+                    },
+                    source = {
+                        id: '53540ee4-8499-44af-9b74-20d415a6fd43',
+                        events: [{
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Alternative request level pre-request script");']
+                            }
+                        }, {
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Alternative request level test script");']
+                            }
+                        }]
+                    };
+
+                transformer.normalizeSingle(source, options, function (err, normalized) {
+                    expect(err).to.not.be.ok;
+
+                    // remove `undefined` properties for testing
+                    normalized = JSON.parse(JSON.stringify(normalized));
+
+                    expect(normalized).to.eql({
+                        id: '53540ee4-8499-44af-9b74-20d415a6fd43',
+                        data: [],
+                        preRequestScript: 'console.log("Alternative request level pre-request script");',
+                        tests: 'console.log("Alternative request level test script");',
+                        events: [{
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Alternative request level pre-request script");']
+                            }
+                        }, {
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Alternative request level test script");']
+                            }
+                        }]
+                    });
+                    done();
+                });
             });
         });
     });


### PR DESCRIPTION
With this pull request:

- [x] `events` and `auth` are no longer treated as unequivocal sources of truth.
- [x] While normalizing v1 collections / converting to v2.x, the following rules now apply:
    1. If both legacy and current properties for auth/scripts are present, the current properties are recreated from the legacy values.
    2. If only current properties are present, the legacy properties are recreated from the current value.
    3. If only legacy properties are present, the current properties are derived from legacy values.
- [x] Unit tests included