### PR TITLE
Event normalization fix

### DIFF
--- a/lib/normalizers/v1.js
+++ b/lib/normalizers/v1.js
@@ -279,12 +279,16 @@ _.assign(Builders.prototype, {
                 }
             });
 
-            preRequestScript && (requestV1.preRequestScript = preRequestScript);
-            tests && (requestV1.tests = tests);
+            requestV1.preRequestScript = preRequestScript ? preRequestScript : null;
+            requestV1.tests = tests ? tests : null;
         }
 
-        _.has(requestV1, 'preRequestScript') && !requestV1.preRequestScript && (delete requestV1.preRequestScript);
-        _.has(requestV1, 'tests') && !requestV1.tests && (delete requestV1.tests);
+        // prune
+        ['preRequestScript', 'tests'].forEach(function (script) {
+            if (_.has(requestV1, script) && !(requestV1[script] || (requestV1[script] === null))) {
+                delete requestV1[script];
+            }
+        });
 
         return requestV1;
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-collection-transformer",
-  "version": "2.4.2",
+  "version": "2.4.3-beta.1",
   "description": "Perform rapid conversation and validation of JSON structure between Postman Collection Format v1 and v2",
   "main": "index.js",
   "scripts": {

--- a/test/unit/v1.0.0/normalize-v1.test.js
+++ b/test/unit/v1.0.0/normalize-v1.test.js
@@ -1304,6 +1304,7 @@ describe('v1.0.0 normalization', function () {
 
                         result = JSON.parse(JSON.stringify(result));
                         expect(result).to.eql({
+                            tests: null,
                             preRequestScript: 'console.log("Pre-request script");',
                             events: [
                                 {
@@ -1360,6 +1361,7 @@ describe('v1.0.0 normalization', function () {
 
                         result = JSON.parse(JSON.stringify(result));
                         expect(result).to.eql({
+                            preRequestScript: null,
                             tests: 'console.log("Test script");',
                             events: [
                                 {
@@ -1515,6 +1517,7 @@ describe('v1.0.0 normalization', function () {
                         expect(err).to.not.be.ok;
 
                         expect(source).to.eql({
+                            tests: null,
                             preRequestScript: 'console.log("Pre-request script");',
                             events: [
                                 {
@@ -1569,6 +1572,7 @@ describe('v1.0.0 normalization', function () {
                         expect(err).to.not.be.ok;
 
                         expect(source).to.eql({
+                            preRequestScript: null,
                             tests: 'console.log("Test script");',
                             events: [
                                 {


### PR DESCRIPTION
In cases where existing event handlers are being removed from current properties, their legacy equivalents will be nullified when being normalized in requests.