### PR TITLE
Prioritize v2 option support

### DIFF
--- a/lib/converters/v1.0.0/converter-v1-to-v2.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v2.js
@@ -217,7 +217,7 @@ _.assign(Builders.prototype, {
         if (!entityV1) { return; }
 
         // events is treated as the source of truth in v1, so handle that first and bail out.
-        if (util.notLegacy(entityV1, 'event') && _.isArray(entityV1.events)) {
+        if ((util.notLegacy(entityV1, 'event') || this.options.prioritizeV2) && !_.isEmpty(entityV1.events)) {
             // in v1, `events` is regarded as the source of truth if it exists, so handle that first and bail out.
             // @todo: Improve this to order prerequest events before test events
             _.forEach(entityV1.events, function (event) {
@@ -272,9 +272,12 @@ _.assign(Builders.prototype, {
      */
     auth: function (entityV1, options) {
         if (!entityV1) { return; }
-        if (util.notLegacy(entityV1, 'auth')) { return util.authArrayToMap(entityV1, options); }
-        if ((entityV1.currentHelper === null) || (entityV1.currentHelper === 'normal')) { return null; }
-        if (!entityV1.currentHelper) { return; }
+        if ((util.notLegacy(entityV1, 'auth') || this.options.prioritizeV2) && entityV1.auth) {
+            return util.authArrayToMap(entityV1, options);
+        }
+        if (!entityV1.currentHelper || (entityV1.currentHelper === null) || (entityV1.currentHelper === 'normal')) {
+            return;
+        }
 
         var params,
             type = v1Common.authMap[entityV1.currentHelper] || entityV1.currentHelper,

--- a/lib/converters/v1.0.0/converter-v1-to-v2.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v2.js
@@ -216,7 +216,7 @@ _.assign(Builders.prototype, {
     event: function (entityV1) {
         if (!entityV1) { return; }
 
-        // events is treated as the source of truth in v1, so handle that first and bail out.
+        // if prioritizeV2 is true, events is used as the source of truth
         if ((util.notLegacy(entityV1, 'event') || this.options.prioritizeV2) && !_.isEmpty(entityV1.events)) {
             // in v1, `events` is regarded as the source of truth if it exists, so handle that first and bail out.
             // @todo: Improve this to order prerequest events before test events

--- a/lib/normalizers/v1.js
+++ b/lib/normalizers/v1.js
@@ -55,17 +55,22 @@ _.assign(Builders.prototype, {
      */
     auth: function (entityV1, options) {
         if (!entityV1) { return; }
-        // Handle the noauth/normal case for new and legacy attributes first, in that order
-        if (util.notLegacy(entityV1, 'auth')) {
-            return util.sanitizeAuthArray(entityV1, options);
-        }
-        if ((entityV1.currentHelper === null) || (entityV1.currentHelper === 'normal')) { return null; }
 
         var auth,
             params,
             mapper,
-            currentHelper = entityV1.currentHelper,
-            helperAttributes = entityV1.helperAttributes;
+            currentHelper,
+            helperAttributes,
+            prioritizeV2 = this.options.prioritizeV2;
+
+        // Handle the noauth/normal case for new and legacy attributes first, in that order
+        if ((util.notLegacy(entityV1, 'auth') || prioritizeV2) && (entityV1.auth || !prioritizeV2)) {
+            return util.sanitizeAuthArray(entityV1, options);
+        }
+        if ((entityV1.currentHelper === null) || (entityV1.currentHelper === 'normal')) { return null; }
+
+        currentHelper = entityV1.currentHelper;
+        helperAttributes = entityV1.helperAttributes;
 
         // if noDefaults is false and there is no currentHelper, bail out
         if (!(currentHelper || this.options.noDefaults)) { return; }
@@ -89,7 +94,8 @@ _.assign(Builders.prototype, {
      * @returns {Array} - The normalized events.
      */
     events: function (entityV1) {
-        if (util.notLegacy(entityV1, 'event') && _.isArray(entityV1 && entityV1.events)) {
+        if (!entityV1) { return; }
+        if ((util.notLegacy(entityV1, 'event') || this.options.prioritizeV2) && !_.isEmpty(entityV1.events)) {
             // @todo: Improve this to order prerequest events before test events
             _.forEach(entityV1.events, function (event) {
                 !event.listen && (event.listen = 'test');
@@ -257,7 +263,7 @@ _.assign(Builders.prototype, {
         (variables = self.variables(requestV1, varOpts)) ? (requestV1.variables = variables) :
             (delete requestV1.variables);
 
-        if (requestV1.auth && util.notLegacy(requestV1, 'auth')) {
+        if (requestV1.auth && (util.notLegacy(requestV1, 'auth') || self.options.prioritizeV2)) {
             requestV1.currentHelper = v2Common.authMap[requestV1.auth.type];
             (requestV1.currentHelper === null) && (requestV1.helperAttributes = null);
 
@@ -267,7 +273,7 @@ _.assign(Builders.prototype, {
             }
         }
 
-        if (requestV1.events && util.notLegacy(requestV1, 'event')) {
+        if (requestV1.events && (util.notLegacy(requestV1, 'event') || self.options.prioritizeV2)) {
             tests = preRequestScript = '';
 
             _.forEach(requestV1.events, function (event) {

--- a/lib/normalizers/v1.js
+++ b/lib/normalizers/v1.js
@@ -63,8 +63,8 @@ _.assign(Builders.prototype, {
             helperAttributes,
             prioritizeV2 = this.options.prioritizeV2;
 
-        // Handle the noauth/normal case for new and legacy attributes first, in that order
-        if ((util.notLegacy(entityV1, 'auth') || prioritizeV2) && (entityV1.auth || !prioritizeV2)) {
+        // if prioritize v2 is true, use auth as the source of truth
+        if (util.notLegacy(entityV1, 'auth') || (entityV1.auth && prioritizeV2)) {
             return util.sanitizeAuthArray(entityV1, options);
         }
         if ((entityV1.currentHelper === null) || (entityV1.currentHelper === 'normal')) { return null; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-collection-transformer",
-  "version": "2.4.3",
+  "version": "2.5.0-beta.1",
   "description": "Perform rapid conversation and validation of JSON structure between Postman Collection Format v1 and v2",
   "main": "index.js",
   "scripts": {

--- a/test/unit/fixtures/sample-collection.js
+++ b/test/unit/fixtures/sample-collection.js
@@ -1896,7 +1896,6 @@ module.exports = {
                             url: "https://echo.getpostman.com/digest-auth",
                             method: "GET",
                             header: [],
-                            auth: null,
                             body: {
                                 mode: "formdata",
                                 formdata: [
@@ -2268,7 +2267,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/oauth1",
                             method: "GET",
                             header: [
@@ -2339,7 +2337,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/cookies/set?foo1=bar1&foo2=bar2",
                                 protocol: "https",
@@ -2453,7 +2450,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/cookies",
                             method: "GET",
                             header: [],
@@ -2562,7 +2558,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/cookies/delete?foo1&foo2",
                                 protocol: "https",
@@ -2685,7 +2680,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/headers",
                             method: "GET",
                             header: [],
@@ -2710,7 +2704,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/response-headers?Content-Type=text/html&Server=apibin",
                                 protocol: "https",
@@ -2782,7 +2775,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/get?test=123",
                                 protocol: "https",
@@ -2848,7 +2840,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/post",
                             method: "POST",
                             header: [
@@ -2893,7 +2884,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/put",
                             method: "PUT",
                             header: [],
@@ -2928,7 +2918,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/patch",
                             method: "PATCH",
                             header: [],
@@ -2963,7 +2952,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/delete",
                             method: "DELETE",
                             header: [],
@@ -3001,7 +2989,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/status/200",
                             method: "GET",
                             header: [],
@@ -3036,7 +3023,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/stream/10",
                             method: "GET",
                             header: [],
@@ -3064,7 +3050,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/delay/3",
                             method: "GET",
                             header: [],
@@ -3097,7 +3082,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/encoding/utf8",
                             method: "GET",
                             header: [],
@@ -3131,7 +3115,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/gzip",
                             method: "GET",
                             header: [],
@@ -3195,7 +3178,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/deflate",
                             method: "GET",
                             header: [],
@@ -3226,7 +3208,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/oauth2/authtoken?client_id=abc123&response_type=code",
                                 protocol: 'https',
@@ -3369,7 +3350,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/oauth2/token",
                             method: "POST",
                             header: [],
@@ -3639,7 +3619,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: "https://echo.getpostman.com/oauth2/user/info",
                             method: "GET",
                             header: [
@@ -3877,7 +3856,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/digest-auth",
                                 protocol: "https",
@@ -4267,7 +4245,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/oauth1",
                                 protocol: "https",
@@ -4343,7 +4320,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/cookies/set?foo1=bar1&foo2=bar2",
                                 protocol: "https",
@@ -4457,7 +4433,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/cookies",
                                 protocol: "https",
@@ -4571,7 +4546,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/cookies/delete?foo1&foo2",
                                 protocol: "https",
@@ -4694,7 +4668,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/headers",
                                 protocol: "https",
@@ -4724,7 +4697,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/response-headers?Content-Type=text/html&Server=apibin",
                                 protocol: "https",
@@ -4796,7 +4768,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/get?test=123",
                                 protocol: "https",
@@ -4862,7 +4833,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/post",
                                 protocol: "https",
@@ -4912,7 +4882,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/put",
                                 protocol: "https",
@@ -4952,7 +4921,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/patch",
                                 protocol: "https",
@@ -4992,7 +4960,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/delete",
                                 protocol: "https",
@@ -5035,7 +5002,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/status/200",
                                 protocol: "https",
@@ -5075,7 +5041,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/stream/10",
                                 protocol: "https",
@@ -5108,7 +5073,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/delay/3",
                                 protocol: "https",
@@ -5146,7 +5110,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/encoding/utf8",
                                 protocol: "https",
@@ -5185,7 +5148,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/gzip",
                                 protocol: "https",
@@ -5254,7 +5216,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/deflate",
                                 protocol: "https",
@@ -5290,7 +5251,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/oauth2/authtoken?client_id=abc123&response_type=code",
                                 protocol: "https",
@@ -5433,7 +5393,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/oauth2/token",
                                 protocol: "https",
@@ -5718,7 +5677,6 @@ module.exports = {
                             }
                         ],
                         request: {
-                            auth: null,
                             url: {
                                 raw: "https://echo.getpostman.com/oauth2/user/info",
                                 protocol: "https",

--- a/test/unit/fixtures/single-request.js
+++ b/test/unit/fixtures/single-request.js
@@ -338,7 +338,6 @@ module.exports = {
                 { key: 'C', value: 'D' },
                 { key: 'E', value: 'F', disabled: true }
             ],
-            auth: null,
             body: {
                 mode: "formdata",
                 formdata: [
@@ -605,7 +604,6 @@ module.exports = {
             }
         ],
         request: {
-            auth: null,
             url: {
                 raw: 'https://yo.postman.wtf/oauth2/token',
                 protocol: 'https',

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -493,6 +493,84 @@ describe('v1.0.0 to v2.0.0', function () {
             });
         });
 
+        describe('with missing properties', function () {
+            var options = {
+                inputVersion: '1.0.0',
+                outputVersion: '2.0.0',
+                retainIds: true
+            };
+
+            it('should fall back to legacy properties if auth is missing', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: 'basicAuth',
+                    helperAttributes: {
+                        id: 'basic',
+                        username: 'postman',
+                        password: 'secret'
+                    }
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' },
+                            auth: {
+                                type: 'basic',
+                                basic: { username: 'postman', password: 'secret', showPassword: false }
+                            }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should discard auth creation if both: legacy and new attributes are missing', function (done) {
+                var source = { id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c' };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should discard auth if both: legacy is normal and new attributes are missing', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: 'normal'
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+        });
+
         describe('prioritizeV2: true', function () {
             var options = {
                 inputVersion: '1.0.0',
@@ -845,6 +923,115 @@ describe('v1.0.0 to v2.0.0', function () {
                     response: []
                 });
                 done();
+            });
+        });
+
+        describe('with missing properties', function () {
+            var options = {
+                inputVersion: '1.0.0',
+                outputVersion: '2.0.0',
+                retainIds: true
+            };
+
+            it('should handle missing preRequestScript and tests correctly', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    events: [{
+                        listen: 'prerequest',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Pre-request script");']
+                        }
+                    }, {
+                        listen: 'test',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Test script");']
+                        }
+                    }]
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        event: [{
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Pre-request script");']
+                            }
+                        }, {
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Test script");']
+                            }
+                        }],
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should handle missing events correctly', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    preRequestScript: 'console.log("Pre-request script");',
+                    tests: 'console.log("Test script");'
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        event: [{
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Test script");']
+                            }
+                        }, {
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Pre-request script");']
+                            }
+                        }],
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should discard property creation if both are absent', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c'
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
             });
         });
 

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -568,6 +568,30 @@ describe('v1.0.0 to v2.0.0', function () {
                 });
             });
 
+            it('should retain type noauth if auth is noauth and currentHelper is null', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: null,
+                    auth: { type: 'noauth' }
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' },
+                            auth: { type: 'noauth' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
             it('should discard auth creation if both: legacy and new attributes are falsy', function (done) {
                 var source = {
                     id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
@@ -611,6 +635,78 @@ describe('v1.0.0 to v2.0.0', function () {
                         response: []
                     });
                     done();
+                });
+            });
+
+            describe('with missing properties', function () {
+                it('should fall back to legacy properties if auth is missing', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        currentHelper: 'basicAuth',
+                        helperAttributes: {
+                            id: 'basic',
+                            username: 'postman',
+                            password: 'secret'
+                        }
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' },
+                                auth: {
+                                    type: 'basic',
+                                    basic: { username: 'postman', password: 'secret', showPassword: false }
+                                }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
+                });
+
+                it('should discard auth creation if both: legacy and new attributes are missing', function (done) {
+                    var source = { id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c' };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
+                });
+
+                it('should discard auth if both: legacy is normal and new attributes are missing', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        currentHelper: 'normal'
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
                 });
             });
         });
@@ -858,6 +954,109 @@ describe('v1.0.0 to v2.0.0', function () {
                         response: []
                     });
                     done();
+                });
+            });
+
+            describe('with missing properties', function () {
+                it('should handle missing preRequestScript and tests correctly', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        events: [{
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Pre-request script");']
+                            }
+                        }, {
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Test script");']
+                            }
+                        }]
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            event: [{
+                                listen: 'prerequest',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Pre-request script");']
+                                }
+                            }, {
+                                listen: 'test',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Test script");']
+                                }
+                            }],
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
+                });
+
+                it('should handle missing events correctly', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        preRequestScript: 'console.log("Pre-request script");',
+                        tests: 'console.log("Test script");'
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Test script");']
+                                }
+                            }, {
+                                listen: 'prerequest',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Pre-request script");']
+                                }
+                            }],
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
+                });
+
+                it('should discard property creation if both are absent', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c'
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
                 });
             });
         });

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -443,6 +443,27 @@ describe('v1.0.0 to v2.0.0', function () {
                         done();
                     });
                 });
+
+                it('should discard auth if both: legacy is null and new attributes are missing', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        currentHelper: null
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
+                });
             });
         });
 
@@ -563,6 +584,37 @@ describe('v1.0.0 to v2.0.0', function () {
                         request: {
                             header: [],
                             body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should handle valid auth and missing legacy properties correctly', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    auth: {
+                        type: 'basic',
+                        basic: [
+                            { key: 'username', value: 'postman', type: 'string' },
+                            { key: 'password', value: 'secret', type: 'string' }
+                        ]
+                    }
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' },
+                            auth: {
+                                type: 'basic',
+                                basic: { username: 'postman', password: 'secret' }
+                            }
                         },
                         response: []
                     });
@@ -693,10 +745,33 @@ describe('v1.0.0 to v2.0.0', function () {
                 });
             });
 
-            it('should discard auth creation if both: legacy is normal and new attributes is falsy', function (done) {
+            it('should discard auth creation if both: legacy is normal and new attributes are falsy', function (done) {
                 var source = {
                     id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
                     currentHelper: 'normal',
+                    helperAttributes: null,
+                    auth: null
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should discard auth creation if both: legacy is null and new attributes are falsy', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: null,
                     helperAttributes: null,
                     auth: null
                 };
@@ -780,6 +855,37 @@ describe('v1.0.0 to v2.0.0', function () {
                             request: {
                                 header: [],
                                 body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
+                });
+
+                it('should handle valid auth and missing legacy properties correctly', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        auth: {
+                            type: 'basic',
+                            basic: [
+                                { key: 'username', value: 'postman', type: 'string' },
+                                { key: 'password', value: 'secret', type: 'string' }
+                            ]
+                        }
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' },
+                                auth: {
+                                    type: 'basic',
+                                    basic: { username: 'postman', password: 'secret' }
+                                }
                             },
                             response: []
                         });
@@ -933,52 +1039,6 @@ describe('v1.0.0 to v2.0.0', function () {
                 retainIds: true
             };
 
-            it('should handle missing preRequestScript and tests correctly', function (done) {
-                var source = {
-                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
-                    events: [{
-                        listen: 'prerequest',
-                        script: {
-                            type: 'text/javascript',
-                            exec: ['console.log("Pre-request script");']
-                        }
-                    }, {
-                        listen: 'test',
-                        script: {
-                            type: 'text/javascript',
-                            exec: ['console.log("Test script");']
-                        }
-                    }]
-                };
-
-                transformer.convertSingle(source, options, function (err, result) {
-                    expect(err).to.not.be.ok;
-                    expect(JSON.parse(JSON.stringify(result))).to.eql({
-                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
-                        name: '',
-                        event: [{
-                            listen: 'prerequest',
-                            script: {
-                                type: 'text/javascript',
-                                exec: ['console.log("Pre-request script");']
-                            }
-                        }, {
-                            listen: 'test',
-                            script: {
-                                type: 'text/javascript',
-                                exec: ['console.log("Test script");']
-                            }
-                        }],
-                        request: {
-                            header: [],
-                            body: { mode: 'raw', raw: '' }
-                        },
-                        response: []
-                    });
-                    done();
-                });
-            });
-
             it('should handle missing events correctly', function (done) {
                 var source = {
                     id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
@@ -1126,6 +1186,29 @@ describe('v1.0.0 to v2.0.0', function () {
                     id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
                     preRequestScript: null,
                     tests: null,
+                    events: []
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should handle empty legacy strings correctly', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    preRequestScript: '',
+                    tests: '',
                     events: []
                 };
 

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -258,7 +258,6 @@ describe('v1.0.0 to v2.0.0', function () {
                 expect(JSON.parse(JSON.stringify(converted))).to.eql({
                     name: '',
                     request: {
-                        auth: null,
                         body: { mode: 'raw', raw: '' },
                         header: []
                     },
@@ -303,7 +302,6 @@ describe('v1.0.0 to v2.0.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -330,7 +328,6 @@ describe('v1.0.0 to v2.0.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -352,7 +349,6 @@ describe('v1.0.0 to v2.0.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -375,7 +371,6 @@ describe('v1.0.0 to v2.0.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -395,7 +390,6 @@ describe('v1.0.0 to v2.0.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -415,7 +409,6 @@ describe('v1.0.0 to v2.0.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -442,7 +435,6 @@ describe('v1.0.0 to v2.0.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -493,9 +485,130 @@ describe('v1.0.0 to v2.0.0', function () {
                             schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
                         },
                         item: [{
-                            auth: null,
                             item: []
                         }]
+                    });
+                    done();
+                });
+            });
+        });
+
+        describe('prioritizeV2: true', function () {
+            var options = {
+                inputVersion: '1.0.0',
+                outputVersion: '2.0.0',
+                prioritizeV2: true,
+                retainIds: true
+            };
+
+            it('should correctly prioritize v2 auth whilst converting', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: 'basicAuth',
+                    helperAttributes: {
+                        id: 'basic',
+                        username: 'postman',
+                        password: 'secret'
+                    },
+                    auth: {
+                        type: 'bearer',
+                        bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                    }
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' },
+                            auth: {
+                                type: 'bearer',
+                                bearer: { token: 'secret' }
+                            }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should fall back to legacy properties if auth is falsy', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: 'basicAuth',
+                    helperAttributes: {
+                        id: 'basic',
+                        username: 'postman',
+                        password: 'secret'
+                    },
+                    auth: null
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' },
+                            auth: {
+                                type: 'basic',
+                                basic: { username: 'postman', password: 'secret', showPassword: false }
+                            }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should discard auth creation if both: legacy and new attributes are falsy', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: null,
+                    helperAttributes: null,
+                    auth: null
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should discard auth creation if both: legacy is normal and new attributes is falsy', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: 'normal',
+                    helperAttributes: null,
+                    auth: null
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
                     });
                     done();
                 });
@@ -636,6 +749,116 @@ describe('v1.0.0 to v2.0.0', function () {
                     response: []
                 });
                 done();
+            });
+        });
+
+        describe('prioritizeV2: true', function () {
+            var options = {
+                inputVersion: '1.0.0',
+                outputVersion: '2.0.0',
+                prioritizeV2: true,
+                retainIds: true
+            };
+
+            it('should correctly prioritize `events` over preRequestScript/tests', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    preRequestScript: 'console.log("Legacy prerequest script");',
+                    tests: 'console.log("Legacy test script");',
+                    events: [{
+                        listen: 'prerequest',
+                        script: { exec: ['console.log("Actual prerequest script");'] }
+                    }, {
+                        listen: 'test',
+                        script: { exec: ['console.log("Actual test script");'] }
+                    }]
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: [],
+                        event: [{
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Actual prerequest script");']
+                            }
+                        }, {
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Actual test script");']
+                            }
+                        }]
+                    });
+                    done();
+                });
+            });
+
+            it('should correctly fall back to preRequestScript/tests if `events` is empty', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    preRequestScript: 'console.log("Legacy prerequest script");',
+                    tests: 'console.log("Legacy test script");',
+                    events: []
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: [],
+                        event: [{
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Legacy test script");']
+                            }
+                        }, {
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Legacy prerequest script");']
+                            }
+                        }]
+                    });
+                    done();
+                });
+            });
+
+            it('should discard event from the result if both legacy and current attributes are empty', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    preRequestScript: null,
+                    tests: null,
+                    events: []
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
             });
         });
     });

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -444,6 +444,27 @@ describe('v1.0.0 to v2.1.0', function () {
                         done();
                     });
                 });
+
+                it('should discard auth if both: legacy is null and new attributes are missing', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        currentHelper: null
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
+                });
             });
         });
 
@@ -569,6 +590,34 @@ describe('v1.0.0 to v2.1.0', function () {
                         request: {
                             header: [],
                             body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should handle valid auth and missing legacy properties correctly', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    auth: {
+                        type: 'bearer',
+                        bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                    }
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' },
+                            auth: {
+                                type: 'bearer',
+                                bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                            }
                         },
                         response: []
                     });
@@ -704,10 +753,33 @@ describe('v1.0.0 to v2.1.0', function () {
                 });
             });
 
-            it('should discard auth creation if both: legacy is normal and new attributes is falsy', function (done) {
+            it('should discard auth creation if both: legacy is normal and new attributes are falsy', function (done) {
                 var source = {
                     id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
                     currentHelper: 'normal',
+                    helperAttributes: null,
+                    auth: null
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should discard auth creation if both: legacy is null and new attributes are falsy', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: null,
                     helperAttributes: null,
                     auth: null
                 };
@@ -796,6 +868,34 @@ describe('v1.0.0 to v2.1.0', function () {
                             request: {
                                 header: [],
                                 body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
+                });
+
+                it('should handle valid auth and missing legacy properties correctly', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        auth: {
+                            type: 'bearer',
+                            bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                        }
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' },
+                                auth: {
+                                    type: 'bearer',
+                                    bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                                }
                             },
                             response: []
                         });
@@ -949,52 +1049,6 @@ describe('v1.0.0 to v2.1.0', function () {
                 retainIds: true
             };
 
-            it('should handle missing preRequestScript and tests correctly', function (done) {
-                var source = {
-                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
-                    events: [{
-                        listen: 'prerequest',
-                        script: {
-                            type: 'text/javascript',
-                            exec: ['console.log("Pre-request script");']
-                        }
-                    }, {
-                        listen: 'test',
-                        script: {
-                            type: 'text/javascript',
-                            exec: ['console.log("Test script");']
-                        }
-                    }]
-                };
-
-                transformer.convertSingle(source, options, function (err, result) {
-                    expect(err).to.not.be.ok;
-                    expect(JSON.parse(JSON.stringify(result))).to.eql({
-                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
-                        name: '',
-                        event: [{
-                            listen: 'prerequest',
-                            script: {
-                                type: 'text/javascript',
-                                exec: ['console.log("Pre-request script");']
-                            }
-                        }, {
-                            listen: 'test',
-                            script: {
-                                type: 'text/javascript',
-                                exec: ['console.log("Test script");']
-                            }
-                        }],
-                        request: {
-                            header: [],
-                            body: { mode: 'raw', raw: '' }
-                        },
-                        response: []
-                    });
-                    done();
-                });
-            });
-
             it('should handle missing events correctly', function (done) {
                 var source = {
                     id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
@@ -1142,6 +1196,29 @@ describe('v1.0.0 to v2.1.0', function () {
                     id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
                     preRequestScript: null,
                     tests: null,
+                    events: []
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            body: { mode: 'raw', raw: '' },
+                            header: []
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should handle empty legacy script strings correctly', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    preRequestScript: '',
+                    tests: '',
                     events: []
                 };
 

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -574,6 +574,30 @@ describe('v1.0.0 to v2.1.0', function () {
                 });
             });
 
+            it('should retain type noauth if auth is noauth and currentHelper is null', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: null,
+                    auth: { type: 'noauth' }
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' },
+                            auth: { type: 'noauth' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
             it('should discard auth creation if both: legacy and new attributes are falsy', function (done) {
                 var source = {
                     id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
@@ -617,6 +641,83 @@ describe('v1.0.0 to v2.1.0', function () {
                         response: []
                     });
                     done();
+                });
+            });
+
+            describe('with missing properties', function () {
+                it('should fall back to legacy properties if auth is missing', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        currentHelper: 'basicAuth',
+                        helperAttributes: {
+                            id: 'basic',
+                            username: 'postman',
+                            password: 'secret'
+                        }
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' },
+                                auth: {
+                                    type: 'basic',
+                                    basic: [
+                                        { key: 'username', value: 'postman', type: 'string' },
+                                        { key: 'password', value: 'secret', type: 'string' },
+                                        { key: 'saveHelperData', type: 'any' },
+                                        { key: 'showPassword', value: false, type: 'boolean' }
+                                    ]
+                                }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
+                });
+
+                it('should discard auth creation if both: legacy and new attributes are missing', function (done) {
+                    var source = { id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c' };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
+                });
+
+                it('should discard auth if both: legacy is normal and new attributes are missing', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        currentHelper: 'normal'
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
                 });
             });
         });
@@ -864,6 +965,109 @@ describe('v1.0.0 to v2.1.0', function () {
                         response: []
                     });
                     done();
+                });
+            });
+
+            describe('with missing properties', function () {
+                it('should handle missing preRequestScript and tests correctly', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        events: [{
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Pre-request script");']
+                            }
+                        }, {
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Test script");']
+                            }
+                        }]
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            event: [{
+                                listen: 'prerequest',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Pre-request script");']
+                                }
+                            }, {
+                                listen: 'test',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Test script");']
+                                }
+                            }],
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
+                });
+
+                it('should handle missing events correctly', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        preRequestScript: 'console.log("Pre-request script");',
+                        tests: 'console.log("Test script");'
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            event: [{
+                                listen: 'test',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Test script");']
+                                }
+                            }, {
+                                listen: 'prerequest',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Pre-request script");']
+                                }
+                            }],
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
+                });
+
+                it('should discard property creation if both are absent', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c'
+                    };
+
+                    transformer.convertSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            name: '',
+                            request: {
+                                header: [],
+                                body: { mode: 'raw', raw: '' }
+                            },
+                            response: []
+                        });
+                        done();
+                    });
                 });
             });
         });

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -494,6 +494,89 @@ describe('v1.0.0 to v2.1.0', function () {
             });
         });
 
+        describe('with missing properties', function () {
+            var options = {
+                inputVersion: '1.0.0',
+                outputVersion: '2.1.0',
+                retainIds: true
+            };
+
+            it('should fall back to legacy properties if auth is missing', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: 'basicAuth',
+                    helperAttributes: {
+                        id: 'basic',
+                        username: 'postman',
+                        password: 'secret'
+                    }
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' },
+                            auth: {
+                                type: 'basic',
+                                basic: [
+                                    { key: 'username', value: 'postman', type: 'string' },
+                                    { key: 'password', value: 'secret', type: 'string' },
+                                    { key: 'saveHelperData', type: 'any' },
+                                    { key: 'showPassword', value: false, type: 'boolean' }
+                                ]
+                            }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should discard auth creation if both: legacy and new attributes are missing', function (done) {
+                var source = { id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c' };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should discard auth if both: legacy is normal and new attributes are missing', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: 'normal'
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+        });
+
         describe('prioritizeV2: true', function () {
             var options = {
                 inputVersion: '1.0.0',
@@ -856,6 +939,115 @@ describe('v1.0.0 to v2.1.0', function () {
                     response: []
                 });
                 done();
+            });
+        });
+
+        describe('with missing properties', function () {
+            var options = {
+                inputVersion: '1.0.0',
+                outputVersion: '2.1.0',
+                retainIds: true
+            };
+
+            it('should handle missing preRequestScript and tests correctly', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    events: [{
+                        listen: 'prerequest',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Pre-request script");']
+                        }
+                    }, {
+                        listen: 'test',
+                        script: {
+                            type: 'text/javascript',
+                            exec: ['console.log("Test script");']
+                        }
+                    }]
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        event: [{
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Pre-request script");']
+                            }
+                        }, {
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Test script");']
+                            }
+                        }],
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should handle missing events correctly', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    preRequestScript: 'console.log("Pre-request script");',
+                    tests: 'console.log("Test script");'
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        event: [{
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Test script");']
+                            }
+                        }, {
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Pre-request script");']
+                            }
+                        }],
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should discard property creation if both are absent', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c'
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
             });
         });
 

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -259,7 +259,6 @@ describe('v1.0.0 to v2.1.0', function () {
                 expect(JSON.parse(JSON.stringify(converted))).to.eql({
                     name: '',
                     request: {
-                        auth: null,
                         body: { mode: 'raw', raw: '' },
                         header: []
                     },
@@ -304,7 +303,6 @@ describe('v1.0.0 to v2.1.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -331,7 +329,6 @@ describe('v1.0.0 to v2.1.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -353,7 +350,6 @@ describe('v1.0.0 to v2.1.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -376,7 +372,6 @@ describe('v1.0.0 to v2.1.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -396,7 +391,6 @@ describe('v1.0.0 to v2.1.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -416,7 +410,6 @@ describe('v1.0.0 to v2.1.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -443,7 +436,6 @@ describe('v1.0.0 to v2.1.0', function () {
                         expect(JSON.parse(JSON.stringify(converted))).to.eql({
                             name: '',
                             request: {
-                                auth: null,
                                 body: { mode: 'raw', raw: '' },
                                 header: []
                             },
@@ -494,9 +486,135 @@ describe('v1.0.0 to v2.1.0', function () {
                             schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
                         },
                         item: [{
-                            auth: null,
                             item: []
                         }]
+                    });
+                    done();
+                });
+            });
+        });
+
+        describe('prioritizeV2: true', function () {
+            var options = {
+                inputVersion: '1.0.0',
+                outputVersion: '2.1.0',
+                prioritizeV2: true,
+                retainIds: true
+            };
+
+            it('should correctly prioritize v2 auth whilst converting', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: 'basicAuth',
+                    helperAttributes: {
+                        id: 'basic',
+                        username: 'postman',
+                        password: 'secret'
+                    },
+                    auth: {
+                        type: 'bearer',
+                        bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                    }
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' },
+                            auth: {
+                                type: 'bearer',
+                                bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                            }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should fall back to legacy properties if auth is falsy', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: 'basicAuth',
+                    helperAttributes: {
+                        id: 'basic',
+                        username: 'postman',
+                        password: 'secret'
+                    },
+                    auth: null
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' },
+                            auth: {
+                                type: 'basic',
+                                basic: [
+                                    { key: 'username', value: 'postman', type: 'string' },
+                                    { key: 'password', value: 'secret', type: 'string' },
+                                    { key: 'saveHelperData', type: 'any' },
+                                    { key: 'showPassword', type: 'boolean', value: false }
+                                ]
+                            }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should discard auth creation if both: legacy and new attributes are falsy', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: null,
+                    helperAttributes: null,
+                    auth: null
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
+                    });
+                    done();
+                });
+            });
+
+            it('should discard auth creation if both: legacy is normal and new attributes is falsy', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    currentHelper: 'normal',
+                    helperAttributes: null,
+                    auth: null
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: []
                     });
                     done();
                 });
@@ -637,6 +755,116 @@ describe('v1.0.0 to v2.1.0', function () {
                     response: []
                 });
                 done();
+            });
+        });
+
+        describe('prioritizeV2: true', function () {
+            var options = {
+                inputVersion: '1.0.0',
+                outputVersion: '2.1.0',
+                prioritizeV2: true,
+                retainIds: true
+            };
+
+            it('should correctly prioritize `events` over preRequestScript/tests', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    preRequestScript: 'console.log("Legacy prerequest script");',
+                    tests: 'console.log("Legacy test script");',
+                    events: [{
+                        listen: 'prerequest',
+                        script: { exec: ['console.log("Actual prerequest script");'] }
+                    }, {
+                        listen: 'test',
+                        script: { exec: ['console.log("Actual test script");'] }
+                    }]
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: [],
+                        event: [{
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Actual prerequest script");']
+                            }
+                        }, {
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Actual test script");']
+                            }
+                        }]
+                    });
+                    done();
+                });
+            });
+
+            it('should correctly fall back to preRequestScript/tests if `events` is empty', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    preRequestScript: 'console.log("Legacy prerequest script");',
+                    tests: 'console.log("Legacy test script");',
+                    events: []
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            header: [],
+                            body: { mode: 'raw', raw: '' }
+                        },
+                        response: [],
+                        event: [{
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Legacy test script");']
+                            }
+                        }, {
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Legacy prerequest script");']
+                            }
+                        }]
+                    });
+                    done();
+                });
+            });
+
+            it('should discard event from the result if both legacy and current attributes are empty', function (done) {
+                var source = {
+                    id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                    preRequestScript: null,
+                    tests: null,
+                    events: []
+                };
+
+                transformer.convertSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        _postman_id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        name: '',
+                        request: {
+                            body: { mode: 'raw', raw: '' },
+                            header: []
+                        },
+                        response: []
+                    });
+                    done();
+                });
             });
         });
     });

--- a/test/unit/v1.0.0/normalize-v1.test.js
+++ b/test/unit/v1.0.0/normalize-v1.test.js
@@ -669,6 +669,31 @@ describe('v1.0.0 normalization', function () {
                         done();
                     });
                 });
+
+                it('should handle valid auth and missing currentHelper correctly', function (done) {
+                    var source = {
+                        auth: {
+                            type: 'bearer',
+                            bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                        }
+                    };
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            auth: {
+                                type: 'bearer',
+                                bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                            },
+                            currentHelper: 'bearerAuth',
+                            helperAttributes: {
+                                id: 'bearer',
+                                token: 'secret'
+                            }
+                        });
+                        done();
+                    });
+                });
             });
 
             describe('prioritizeV2: true', function () {
@@ -788,6 +813,34 @@ describe('v1.0.0 normalization', function () {
                             currentHelper: null,
                             helperAttributes: null,
                             auth: null
+                        });
+                        done();
+                    });
+                });
+
+                it('should handle valid auth and missing currentHelper correctly', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        auth: {
+                            type: 'bearer',
+                            bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                        }
+                    };
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            data: [],
+                            auth: {
+                                type: 'bearer',
+                                bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                            },
+                            currentHelper: 'bearerAuth',
+                            helperAttributes: {
+                                id: 'bearer',
+                                token: 'secret'
+                            }
                         });
                         done();
                     });

--- a/test/unit/v1.0.0/normalize-v1.test.js
+++ b/test/unit/v1.0.0/normalize-v1.test.js
@@ -933,6 +933,98 @@ describe('v1.0.0 normalization', function () {
                         done();
                     });
                 });
+
+                describe('with missing properties', function () {
+                    it('should handle missing preRequestScript and tests correctly', function (done) {
+                        var source = {
+                            id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            events: [{
+                                listen: 'prerequest',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Pre-request script");']
+                                }
+                            }, {
+                                listen: 'test',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Test script");']
+                                }
+                            }]
+                        };
+
+                        transformer.normalizeSingle(source, options, function (err, result) {
+                            expect(err).to.not.be.ok;
+                            expect(JSON.parse(JSON.stringify(result))).to.eql({
+                                id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                                data: [],
+                                preRequestScript: 'console.log("Pre-request script");',
+                                tests: 'console.log("Test script");',
+                                events: [{
+                                    listen: 'prerequest',
+                                    script: {
+                                        type: 'text/javascript',
+                                        exec: ['console.log("Pre-request script");']
+                                    }
+                                }, {
+                                    listen: 'test',
+                                    script: {
+                                        type: 'text/javascript',
+                                        exec: ['console.log("Test script");']
+                                    }
+                                }]
+                            });
+                            done();
+                        });
+                    });
+
+                    it('should handle missing events correctly', function (done) {
+                        var source = {
+                            id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            preRequestScript: 'console.log("Pre-request script");',
+                            tests: 'console.log("Test script");'
+                        };
+
+                        transformer.normalizeSingle(source, options, function (err, result) {
+                            expect(err).to.not.be.ok;
+                            expect(JSON.parse(JSON.stringify(result))).to.eql({
+                                id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                                data: [],
+                                events: [{
+                                    listen: 'prerequest',
+                                    script: {
+                                        type: 'text/javascript',
+                                        exec: ['console.log("Pre-request script");']
+                                    }
+                                }, {
+                                    listen: 'test',
+                                    script: {
+                                        type: 'text/javascript',
+                                        exec: ['console.log("Test script");']
+                                    }
+                                }],
+                                preRequestScript: 'console.log("Pre-request script");',
+                                tests: 'console.log("Test script");'
+                            });
+                            done();
+                        });
+                    });
+
+                    it('should discard property creation if both are absent', function (done) {
+                        var source = {
+                            id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c'
+                        };
+
+                        transformer.normalizeSingle(source, options, function (err, result) {
+                            expect(err).to.not.be.ok;
+                            expect(JSON.parse(JSON.stringify(result))).to.eql({
+                                id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                                data: []
+                            });
+                            done();
+                        });
+                    });
+                });
             });
         });
     });
@@ -1807,6 +1899,361 @@ describe('v1.0.0 normalization', function () {
                                 }
                             ]
                         });
+                    });
+                });
+            });
+        });
+    });
+
+    describe('prioritizeV2, noDefaults: true', function () {
+        var options = {
+            noDefaults: true,
+            prioritizeV2: true,
+            normalizeVersion: '1.0.0'
+        };
+
+        describe('auth', function () {
+            it('should correctly prioritize v2 auth whilst normalizing', function (done) {
+                var source = {
+                    currentHelper: 'basicAuth',
+                    helperAttributes: {
+                        id: 'basic',
+                        username: 'postman',
+                        password: 'secret'
+                    },
+                    auth: {
+                        type: 'bearer',
+                        bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                    }
+                };
+
+                transformer.normalizeSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+
+                    expect(result).to.eql({
+                        currentHelper: 'bearerAuth',
+                        helperAttributes: {
+                            id: 'bearer',
+                            token: 'secret'
+                        },
+                        auth: {
+                            type: 'bearer',
+                            bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                        }
+                    });
+                    done();
+                });
+            });
+
+            it('should fall back to legacy properties if auth is falsy', function (done) {
+                var source = {
+                    currentHelper: 'basicAuth',
+                    helperAttributes: {
+                        id: 'basic',
+                        username: 'postman',
+                        password: 'secret'
+                    },
+                    auth: null
+                };
+
+                transformer.normalizeSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        currentHelper: 'basicAuth',
+                        helperAttributes: {
+                            id: 'basic',
+                            username: 'postman',
+                            password: 'secret'
+                        },
+                        auth: {
+                            type: 'basic',
+                            basic: [
+                                { key: 'username', value: 'postman', type: 'string' },
+                                { key: 'password', value: 'secret', type: 'string' },
+                                { key: 'saveHelperData', type: 'any' },
+                                { key: 'showPassword', value: false, type: 'boolean' }
+                            ]
+                        }
+                    });
+                    done();
+                });
+            });
+
+            it('should retain type noauth if auth is noauth and currentHelper is null', function (done) {
+                var source = {
+                    currentHelper: null,
+                    auth: { type: 'noauth' }
+                };
+
+                transformer.normalizeSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        currentHelper: null,
+                        helperAttributes: null,
+                        auth: { type: 'noauth' }
+                    });
+                    done();
+                });
+            });
+
+            it('should nullify if both: legacy and new attributes are falsy', function (done) {
+                var source = {
+                    currentHelper: null,
+                    helperAttributes: null,
+                    auth: null
+                };
+
+                transformer.normalizeSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(result).to.eql({
+                        currentHelper: null,
+                        helperAttributes: null,
+                        auth: null
+                    });
+                    done();
+                });
+            });
+
+            it('should nullify auth if both: legacy is normal and the new attribute is falsy', function (done) {
+                var source = {
+                    currentHelper: 'normal',
+                    helperAttributes: null,
+                    auth: null
+                };
+
+                transformer.normalizeSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(result).to.eql({
+                        currentHelper: null,
+                        helperAttributes: null,
+                        auth: null
+                    });
+                    done();
+                });
+            });
+
+            describe('with missing properties', function () {
+                it('should fall back to legacy properties if auth is missing', function (done) {
+                    var source = {
+                        currentHelper: 'basicAuth',
+                        helperAttributes: {
+                            id: 'basic',
+                            username: 'postman',
+                            password: 'secret'
+                        }
+                    };
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            currentHelper: 'basicAuth',
+                            helperAttributes: {
+                                id: 'basic',
+                                username: 'postman',
+                                password: 'secret'
+                            },
+                            auth: {
+                                type: 'basic',
+                                basic: [
+                                    { key: 'username', value: 'postman', type: 'string' },
+                                    { key: 'password', value: 'secret', type: 'string' },
+                                    { key: 'saveHelperData', type: 'any' },
+                                    { key: 'showPassword', value: false, type: 'boolean' }
+                                ]
+                            }
+                        });
+                        done();
+                    });
+                });
+
+                it('should discard auth creation if both: legacy and new attributes are missing', function (done) {
+                    var source = {};
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({});
+                        done();
+                    });
+                });
+
+                it('should discard auth if both: legacy is normal and new attributes are missing', function (done) {
+                    var source = { currentHelper: 'normal' };
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            auth: null,
+                            currentHelper: null,
+                            helperAttributes: null
+                        });
+                        done();
+                    });
+                });
+            });
+        });
+
+        describe('scripts', function () {
+            it('should correctly prioritize `events` over preRequestScript/tests', function (done) {
+                var source = {
+                    preRequestScript: 'console.log("Legacy prerequest script");',
+                    tests: 'console.log("Legacy test script");',
+                    events: [{
+                        listen: 'prerequest',
+                        script: { exec: ['console.log("Actual prerequest script");'] }
+                    }, {
+                        listen: 'test',
+                        script: { exec: ['console.log("Actual test script");'] }
+                    }]
+                };
+
+                transformer.normalizeSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(result).to.eql({
+                        preRequestScript: 'console.log("Actual prerequest script");',
+                        tests: 'console.log("Actual test script");',
+                        events: [{
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Actual prerequest script");']
+                            }
+                        }, {
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Actual test script");']
+                            }
+                        }]
+                    });
+                    done();
+                });
+            });
+
+            it('should correctly fall back to preRequestScript/tests if `events` is empty', function (done) {
+                var source = {
+                    preRequestScript: 'console.log("Legacy prerequest script");',
+                    tests: 'console.log("Legacy test script");',
+                    events: []
+                };
+
+                transformer.normalizeSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(result).to.eql({
+                        preRequestScript: 'console.log("Legacy prerequest script");',
+                        tests: 'console.log("Legacy test script");',
+                        events: [{
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Legacy prerequest script");']
+                            }
+                        }, {
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Legacy test script");']
+                            }
+                        }]
+                    });
+                    done();
+                });
+            });
+
+            it('should nullify the event if both legacy and current attributes are empty', function (done) {
+                var source = {
+                    preRequestScript: null,
+                    tests: null,
+                    events: []
+                };
+
+                transformer.normalizeSingle(source, options, function (err, result) {
+                    expect(err).to.not.be.ok;
+                    expect(result).to.eql({
+                        preRequestScript: null,
+                        tests: null
+                    });
+                    done();
+                });
+            });
+
+            describe('with missing properties', function () {
+                it('should handle missing preRequestScript and tests correctly', function (done) {
+                    var source = {
+                        events: [{
+                            listen: 'prerequest',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Pre-request script");']
+                            }
+                        }, {
+                            listen: 'test',
+                            script: {
+                                type: 'text/javascript',
+                                exec: ['console.log("Test script");']
+                            }
+                        }]
+                    };
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            preRequestScript: 'console.log("Pre-request script");',
+                            tests: 'console.log("Test script");',
+                            events: [{
+                                listen: 'prerequest',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Pre-request script");']
+                                }
+                            }, {
+                                listen: 'test',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Test script");']
+                                }
+                            }]
+                        });
+                        done();
+                    });
+                });
+
+                it('should handle missing events correctly', function (done) {
+                    var source = {
+                        preRequestScript: 'console.log("Pre-request script");',
+                        tests: 'console.log("Test script");'
+                    };
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            events: [{
+                                listen: 'prerequest',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Pre-request script");']
+                                }
+                            }, {
+                                listen: 'test',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Test script");']
+                                }
+                            }],
+                            preRequestScript: 'console.log("Pre-request script");',
+                            tests: 'console.log("Test script");'
+                        });
+                        done();
+                    });
+                });
+
+                it('should discard property creation if both are absent', function (done) {
+                    transformer.normalizeSingle({}, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({});
+                        done();
                     });
                 });
             });

--- a/test/unit/v1.0.0/normalize-v1.test.js
+++ b/test/unit/v1.0.0/normalize-v1.test.js
@@ -605,6 +605,129 @@ describe('v1.0.0 normalization', function () {
                     });
                 });
             });
+
+            describe('prioritizeV2: true', function () {
+                var options = {
+                    normalizeVersion: '1.0.0',
+                    prioritizeV2: true,
+                    retainIds: true
+                };
+
+                it('should correctly prioritize v2 auth whilst normalizing', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        currentHelper: 'basicAuth',
+                        helperAttributes: {
+                            id: 'basic',
+                            username: 'postman',
+                            password: 'secret'
+                        },
+                        auth: {
+                            type: 'bearer',
+                            bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                        }
+                    };
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+
+                        expect(result).to.eql({
+                            id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            data: [],
+                            currentHelper: 'bearerAuth',
+                            helperAttributes: {
+                                id: 'bearer',
+                                token: 'secret'
+                            },
+                            auth: {
+                                type: 'bearer',
+                                bearer: [{ key: 'token', value: 'secret', type: 'string' }]
+                            }
+                        });
+                        done();
+                    });
+                });
+
+                it('should fall back to legacy properties if auth is falsy', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        currentHelper: 'basicAuth',
+                        helperAttributes: {
+                            id: 'basic',
+                            username: 'postman',
+                            password: 'secret'
+                        },
+                        auth: null
+                    };
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+
+                        expect(JSON.parse(JSON.stringify(result))).to.eql({
+                            id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            data: [],
+                            currentHelper: 'basicAuth',
+                            helperAttributes: {
+                                id: 'basic',
+                                username: 'postman',
+                                password: 'secret'
+                            },
+                            auth: {
+                                type: 'basic',
+                                basic: [
+                                    { key: 'username', value: 'postman', type: 'string' },
+                                    { key: 'password', value: 'secret', type: 'string' },
+                                    { key: 'saveHelperData', type: 'any' },
+                                    { key: 'showPassword', value: false, type: 'boolean' }
+                                ]
+                            }
+                        });
+                        done();
+                    });
+                });
+
+                it('should nullify if both: legacy and new attributes are falsy', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        currentHelper: null,
+                        helperAttributes: null,
+                        auth: null
+                    };
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(result).to.eql({
+                            id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            data: [],
+                            currentHelper: null,
+                            helperAttributes: null,
+                            auth: null
+                        });
+                        done();
+                    });
+                });
+
+                it('should nullify auth if both: legacy is normal and the new attribute is falsy', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        currentHelper: 'normal',
+                        helperAttributes: null,
+                        auth: null
+                    };
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(result).to.eql({
+                            id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            data: [],
+                            currentHelper: null,
+                            helperAttributes: null,
+                            auth: null
+                        });
+                        done();
+                    });
+                });
+            });
         });
 
         describe('scripts', function () {
@@ -709,6 +832,106 @@ describe('v1.0.0 normalization', function () {
                         }]
                     });
                     done();
+                });
+            });
+
+            describe('prioritizeV2: true', function () {
+                var options = {
+                    normalizeVersion: '1.0.0',
+                    prioritizeV2: true,
+                    retainIds: true
+                };
+
+                it('should correctly prioritize `events` over preRequestScript/tests', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        preRequestScript: 'console.log("Legacy prerequest script");',
+                        tests: 'console.log("Legacy test script");',
+                        events: [{
+                            listen: 'prerequest',
+                            script: { exec: ['console.log("Actual prerequest script");'] }
+                        }, {
+                            listen: 'test',
+                            script: { exec: ['console.log("Actual test script");'] }
+                        }]
+                    };
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(result).to.eql({
+                            id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            data: [],
+                            preRequestScript: 'console.log("Actual prerequest script");',
+                            tests: 'console.log("Actual test script");',
+                            events: [{
+                                listen: 'prerequest',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Actual prerequest script");']
+                                }
+                            }, {
+                                listen: 'test',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Actual test script");']
+                                }
+                            }]
+                        });
+                        done();
+                    });
+                });
+
+                it('should correctly fall back to preRequestScript/tests if `events` is empty', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        preRequestScript: 'console.log("Legacy prerequest script");',
+                        tests: 'console.log("Legacy test script");',
+                        events: []
+                    };
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(result).to.eql({
+                            id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            data: [],
+                            preRequestScript: 'console.log("Legacy prerequest script");',
+                            tests: 'console.log("Legacy test script");',
+                            events: [{
+                                listen: 'prerequest',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Legacy prerequest script");']
+                                }
+                            }, {
+                                listen: 'test',
+                                script: {
+                                    type: 'text/javascript',
+                                    exec: ['console.log("Legacy test script");']
+                                }
+                            }]
+                        });
+                        done();
+                    });
+                });
+
+                it('should nullify the event if both legacy and current attributes are empty', function (done) {
+                    var source = {
+                        id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                        preRequestScript: null,
+                        tests: null,
+                        events: []
+                    };
+
+                    transformer.normalizeSingle(source, options, function (err, result) {
+                        expect(err).to.not.be.ok;
+                        expect(result).to.eql({
+                            id: '27ad5d23-f158-41e2-900d-4f81e62c0a1c',
+                            data: [],
+                            preRequestScript: null,
+                            tests: null
+                        });
+                        done();
+                    });
                 });
             });
         });


### PR DESCRIPTION
Scope:
v1 normalization, v1 -> v2.x transformation

With this pull request:
Operations in the above defined scope will accept an option `prioritizeV2`, which will give preference to v2 style properties for the result of incoming v1 entities.