### PR TITLE
Empty description conversion fix

### DIFF
--- a/lib/converters/v1.0.0/converter-v1-to-v2.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v2.js
@@ -25,12 +25,15 @@ _.assign(Builders.prototype, {
      * @returns {object}
      */
     info: function (collectionV1) {
-        return {
-            name: collectionV1.name,
+        var info = {
             _postman_id: collectionV1.id,
-            description: (collectionV1.description === null) ? '' : collectionV1.description,
-            schema: constants.SCHEMA_V2_URL
+            name: collectionV1.name
         };
+
+        collectionV1.description && (info.description = collectionV1.description);
+        info.schema = constants.SCHEMA_V2_URL;
+
+        return info;
     },
 
     /**
@@ -198,16 +201,6 @@ _.assign(Builders.prototype, {
     },
 
     /**
-     * Constructs a V2 Request compatible "description" from a V1 Postman request
-     *
-     * @param requestV1
-     * @returns {*}
-     */
-    description: function (requestV1) {
-        return requestV1.description;
-    },
-
-    /**
      * Constructs a V2 "events" object from a V1 Postman Request
      *
      * @param entityV1
@@ -310,13 +303,14 @@ _.assign(Builders.prototype, {
      */
     request: function (requestV1) {
         var self = this,
-            units = ['auth', 'method', 'header', 'body', 'url', 'description'],
-            request = {};
+            request = {},
+            units = ['auth', 'method', 'header', 'body', 'url'];
 
         units.forEach(function (unit) {
             request[unit] = self[unit](requestV1);
         });
 
+        requestV1.description && (request.description = requestV1.description);
         return request;
     },
 

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
   },
   "devDependencies": {
     "async": "2.6.0",
-    "browserify": "15.0.0",
+    "browserify": "15.2.0",
     "chai": "4.1.2",
     "chalk": "2.3.0",
-    "eslint": "4.15.0",
+    "eslint": "4.17.0",
     "eslint-plugin-jsdoc": "3.3.1",
-    "eslint-plugin-lodash": "2.5.0",
+    "eslint-plugin-lodash": "2.6.1",
     "eslint-plugin-mocha": "4.11.0",
     "eslint-plugin-security": "1.4.0",
     "js-yaml": "3.10.0",
@@ -52,7 +52,7 @@
     "karma-chrome-launcher": "2.2.0",
     "karma-mocha": "1.3.0",
     "karma-mocha-reporter": "2.2.5",
-    "mocha": "4.1.0",
+    "mocha": "5.0.0",
     "nsp": "2.6.3",
     "nyc": "11.4.1",
     "packity": "0.3.2",
@@ -60,17 +60,17 @@
     "pretty-ms": "3.1.0",
     "recursive-readdir": "2.2.1",
     "require-all": "2.2.0",
-    "shelljs": "0.7.8",
+    "shelljs": "0.8.1",
     "superagent": "3.8.2",
     "tv4": "1.3.0",
-    "watchify": "3.9.0"
+    "watchify": "3.10.0"
   },
   "dependencies": {
-    "commander": "2.12.2",
+    "commander": "2.14.0",
     "inherits": "2.0.3",
     "intel": "1.2.0",
-    "lodash": "4.17.4",
-    "semver": "5.4.1",
+    "lodash": "4.17.5",
+    "semver": "5.5.0",
     "strip-json-comments": "2.0.1"
   }
 }

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -90,13 +90,14 @@ describe('v1.0.0 to v2.0.0', function () {
     });
 
     describe('descriptions', function () {
+        var options = {
+            inputVersion: '1.0.0',
+            outputVersion: '2.0.0',
+            retainIds: true
+        };
+
         it('should correctly handle descriptions whilst converting from v1 to v2', function (done) {
-            var fixture = require('../fixtures/sample-description'),
-                options = {
-                    inputVersion: '1.0.0',
-                    outputVersion: '2.0.0',
-                    retainIds: true
-                };
+            var fixture = require('../fixtures/sample-description');
 
             transformer.convert(fixture.v1, options, function (err, converted) {
                 expect(err).to.not.be.ok;
@@ -105,6 +106,56 @@ describe('v1.0.0 to v2.0.0', function () {
                 converted = JSON.parse(JSON.stringify(converted));
 
                 expect(converted).to.eql(fixture.v2);
+                done();
+            });
+        });
+
+        it('should correctly handle falsy descriptions whilst converting from v1.0.0 to v2.0.0', function (done) {
+            transformer.convert({
+                id: 'C1',
+                name: 'collection',
+                description: null,
+                requests: [{
+                    id: 'R1',
+                    collectionId: 'C1',
+                    name: 'request one',
+                    description: ''
+                }],
+                folders: [{
+                    id: 'F1',
+                    order: ['R1'],
+                    name: 'folder one',
+                    description: undefined
+                }],
+                order: [],
+                folders_order: ['F1']
+            }, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                expect(JSON.parse(JSON.stringify(converted))).to.eql({
+                    info: {
+                        _postman_id: 'C1',
+                        name: 'collection',
+                        schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+                    },
+                    item: [{
+                        _postman_id: 'F1',
+                        name: 'folder one',
+                        item: [{
+                            _postman_id: 'R1',
+                            name: 'request one',
+                            request: {
+                                body: {
+                                    mode: 'raw',
+                                    raw: ''
+                                },
+                                header: []
+                            },
+                            response: []
+                        }]
+                    }]
+                });
                 done();
             });
         });

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -108,6 +108,56 @@ describe('v1.0.0 to v2.1.0', function () {
                 done();
             });
         });
+
+        it('should correctly handle falsy descriptions whilst converting from v1.0.0 to v2.1.0', function (done) {
+            transformer.convert({
+                id: 'C1',
+                name: 'collection',
+                description: null,
+                requests: [{
+                    id: 'R1',
+                    collectionId: 'C1',
+                    name: 'request one',
+                    description: ''
+                }],
+                folders: [{
+                    id: 'F1',
+                    order: ['R1'],
+                    name: 'folder one',
+                    description: undefined
+                }],
+                order: [],
+                folders_order: ['F1']
+            }, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                expect(JSON.parse(JSON.stringify(converted))).to.eql({
+                    info: {
+                        _postman_id: 'C1',
+                        name: 'collection',
+                        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+                    },
+                    item: [{
+                        _postman_id: 'F1',
+                        name: 'folder one',
+                        item: [{
+                            _postman_id: 'R1',
+                            name: 'request one',
+                            request: {
+                                body: {
+                                    mode: 'raw',
+                                    raw: ''
+                                },
+                                header: []
+                            },
+                            response: []
+                        }]
+                    }]
+                });
+                done();
+            });
+        });
     });
 
     describe('request file body', function () {

--- a/test/unit/v2.0.0/converter-v2-to-v1.test.js
+++ b/test/unit/v2.0.0/converter-v2-to-v1.test.js
@@ -187,13 +187,14 @@ describe('v2.0.0 to v1.0.0', function () {
     });
 
     describe('descriptions', function () {
+        var options = {
+            inputVersion: '2.0.0',
+            outputVersion: '1.0.0',
+            retainIds: true
+        };
+
         it('should correctly handle descriptions whilst converting from v2 to v1', function (done) {
-            var fixture = require('../fixtures/sample-description'),
-                options = {
-                    inputVersion: '2.0.0',
-                    outputVersion: '1.0.0',
-                    retainIds: true
-                };
+            var fixture = require('../fixtures/sample-description');
 
             transformer.convert(fixture.v2, options, function (err, converted) {
                 expect(err).to.not.be.ok;
@@ -202,6 +203,52 @@ describe('v2.0.0 to v1.0.0', function () {
                 converted = JSON.parse(JSON.stringify(converted));
 
                 expect(converted).to.eql(fixture.v1);
+                done();
+            });
+        });
+
+        it('should correctly handle falsy descriptions whilst converting from v2.0.0 to v1', function (done) {
+            transformer.convert({
+                info: {
+                    _postman_id: 'C1',
+                    name: 'collection',
+                    description: null
+                },
+                item: [{
+                    _postman_id: 'F1',
+                    name: 'folder one',
+                    description: undefined,
+                    item: [{
+                        _postman_id: 'R1',
+                        name: 'request one',
+                        description: ''
+                    }]
+                }]
+            }, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                expect(JSON.parse(JSON.stringify(converted))).to.eql({
+                    id: 'C1',
+                    name: 'collection',
+                    requests: [{
+                        id: 'R1',
+                        url: '',
+                        data: [],
+                        headerData: [],
+                        rawModeData: '',
+                        collectionId: 'C1',
+                        name: 'request one'
+                    }],
+                    folders: [{
+                        id: 'F1',
+                        order: ['R1'],
+                        folders_order: [],
+                        name: 'folder one'
+                    }],
+                    order: [],
+                    folders_order: ['F1']
+                });
                 done();
             });
         });

--- a/test/unit/v2.1.0/converter-v21-to-v1.test.js
+++ b/test/unit/v2.1.0/converter-v21-to-v1.test.js
@@ -183,13 +183,14 @@ describe('v2.1.0 to v1.0.0', function () {
     });
 
     describe('descriptions', function () {
+        var options = {
+            inputVersion: '2.1.0',
+            outputVersion: '1.0.0',
+            retainIds: true
+        };
+
         it('should correctly handle descriptions whilst converting from v2.1.0 to v1', function (done) {
-            var fixture = require('../fixtures/sample-description'),
-                options = {
-                    inputVersion: '2.1.0',
-                    outputVersion: '1.0.0',
-                    retainIds: true
-                };
+            var fixture = require('../fixtures/sample-description');
 
             transformer.convert(fixture.v21, options, function (err, converted) {
                 expect(err).to.not.be.ok;
@@ -198,6 +199,52 @@ describe('v2.1.0 to v1.0.0', function () {
                 converted = JSON.parse(JSON.stringify(converted));
 
                 expect(converted).to.eql(fixture.v1);
+                done();
+            });
+        });
+
+        it('should correctly handle falsy descriptions whilst converting from v2.1.0 to v1', function (done) {
+            transformer.convert({
+                info: {
+                    _postman_id: 'C1',
+                    name: 'collection',
+                    description: null
+                },
+                item: [{
+                    _postman_id: 'F1',
+                    name: 'folder one',
+                    description: undefined,
+                    item: [{
+                        _postman_id: 'R1',
+                        name: 'request one',
+                        description: ''
+                    }]
+                }]
+            }, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                expect(JSON.parse(JSON.stringify(converted))).to.eql({
+                    id: 'C1',
+                    name: 'collection',
+                    requests: [{
+                        id: 'R1',
+                        url: '',
+                        data: [],
+                        headerData: [],
+                        rawModeData: '',
+                        collectionId: 'C1',
+                        name: 'request one'
+                    }],
+                    folders: [{
+                        id: 'F1',
+                        order: ['R1'],
+                        folders_order: [],
+                        name: 'folder one'
+                    }],
+                    order: [],
+                    folders_order: ['F1']
+                });
                 done();
             });
         });


### PR DESCRIPTION
**This pull request:**
1. Fixes a bug that causes falsy descriptions to slip through in transformations
2. Adds tests for the above fix.

**Scope:**
1. v1 -> v2 transformation
2. No options provided.
3. For requests and collections