### PR TITLE
Type conversion fix for auth and variable

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -65,7 +65,7 @@ util = {
                     id: !(noDefaults || item.id) ? self.uid() : item.id,
                     key: item.key || item.id,
                     value: item.value,
-                    type: item.type || self.typeMap[typeof item.value] || 'any'
+                    type: (item.type === 'text' ? 'string' : item.type) || self.typeMap[typeof item.value] || 'any'
                 };
 
                 item.disabled && (result.disabled = true);
@@ -186,7 +186,7 @@ util = {
                 return {
                     key: param.key,
                     value: param.value,
-                    type: param.type || self.typeMap[typeof param.value] || 'any'
+                    type: (param.type === 'text' ? 'string' : param.type) || self.typeMap[typeof param.value] || 'any'
                 };
             });
         }

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -1417,5 +1417,35 @@ describe('v1.0.0 to v2.0.0', function () {
                 done();
             });
         });
+
+        it('should correctly convert text to string', function (done) {
+            transformer.convert({
+                id: '2509a94e-eca1-43ca-a8aa-0e200636764f',
+                auth: {
+                    type: 'bearer',
+                    bearer: [{ key: 'token', value: 'bar', type: 'text' }]
+                },
+                variables: [{
+                    id: 'f42cc664-4823-4012-b7dd-9e9f965b736a', key: 'foo', value: 'bar', type: 'text'
+                }]
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    info: {
+                        _postman_id: '2509a94e-eca1-43ca-a8aa-0e200636764f',
+                        schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+                    },
+                    auth: {
+                        type: 'bearer',
+                        bearer: { token: 'bar' }
+                    },
+                    item: [],
+                    variable: [{
+                        id: 'f42cc664-4823-4012-b7dd-9e9f965b736a', key: 'foo', value: 'bar', type: 'string'
+                    }]
+                });
+                done();
+            });
+        });
     });
 });

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -1426,5 +1426,35 @@ describe('v1.0.0 to v2.1.0', function () {
                 done();
             });
         });
+
+        it('should correctly convert text to string', function (done) {
+            transformer.convert({
+                id: '2509a94e-eca1-43ca-a8aa-0e200636764f',
+                auth: {
+                    type: 'bearer',
+                    bearer: [{ key: 'token', value: 'bar', type: 'text' }]
+                },
+                variables: [{
+                    id: 'f42cc664-4823-4012-b7dd-9e9f965b736a', key: 'foo', value: 'bar', type: 'text'
+                }]
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    info: {
+                        _postman_id: '2509a94e-eca1-43ca-a8aa-0e200636764f',
+                        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+                    },
+                    auth: {
+                        type: 'bearer',
+                        bearer: [{ key: 'token', value: 'bar', type: 'string' }]
+                    },
+                    item: [],
+                    variable: [{
+                        id: 'f42cc664-4823-4012-b7dd-9e9f965b736a', key: 'foo', value: 'bar', type: 'string'
+                    }]
+                });
+                done();
+            });
+        });
     });
 });

--- a/test/unit/v1.0.0/normalize-v1.test.js
+++ b/test/unit/v1.0.0/normalize-v1.test.js
@@ -2569,5 +2569,31 @@ describe('v1.0.0 normalization', function () {
                 done();
             });
         });
+
+        it('should correctly convert text to string', function (done) {
+            transformer.normalize({
+                id: '2509a94e-eca1-43ca-a8aa-0e200636764f',
+                auth: {
+                    type: 'bearer',
+                    bearer: [{ key: 'token', value: 'bar', type: 'text' }]
+                },
+                variables: [{
+                    id: 'f42cc664-4823-4012-b7dd-9e9f965b736a', key: 'foo', value: 'bar', type: 'text'
+                }]
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    id: '2509a94e-eca1-43ca-a8aa-0e200636764f',
+                    auth: {
+                        type: 'bearer',
+                        bearer: [{ key: 'token', value: 'bar', type: 'string' }]
+                    },
+                    variables: [{
+                        id: 'f42cc664-4823-4012-b7dd-9e9f965b736a', key: 'foo', value: 'bar', type: 'string'
+                    }]
+                });
+                done();
+            });
+        });
     });
 });

--- a/test/unit/v2.0.0/converter-v2-to-v1.test.js
+++ b/test/unit/v2.0.0/converter-v2-to-v1.test.js
@@ -472,5 +472,37 @@ describe('v2.0.0 to v1.0.0', function () {
                 done();
             });
         });
+
+        it('should correctly convert text to string', function (done) {
+            transformer.convert({
+                info: {
+                    _postman_id: '2509a94e-eca1-43ca-a8aa-0e200636764f'
+                },
+                auth: {
+                    type: 'bearer',
+                    bearer: { token: 'bar' }
+                },
+                variable: [{
+                    id: 'f42cc664-4823-4012-b7dd-9e9f965b736a', key: 'foo', value: 'bar', type: 'text'
+                }]
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    id: '2509a94e-eca1-43ca-a8aa-0e200636764f',
+                    auth: {
+                        type: 'bearer',
+                        bearer: [{ key: 'token', value: 'bar', type: 'string' }]
+                    },
+                    folders: [],
+                    folders_order: [],
+                    order: [],
+                    requests: [],
+                    variables: [{
+                        id: 'f42cc664-4823-4012-b7dd-9e9f965b736a', key: 'foo', value: 'bar', type: 'string'
+                    }]
+                });
+                done();
+            });
+        });
     });
 });

--- a/test/unit/v2.1.0/converter-v21-to-v1.test.js
+++ b/test/unit/v2.1.0/converter-v21-to-v1.test.js
@@ -474,5 +474,37 @@ describe('v2.1.0 to v1.0.0', function () {
                 done();
             });
         });
+
+        it('should correctly convert text to string', function (done) {
+            transformer.convert({
+                info: {
+                    _postman_id: '2509a94e-eca1-43ca-a8aa-0e200636764f'
+                },
+                auth: {
+                    type: 'bearer',
+                    bearer: [{ key: 'token', value: 'bar', type: 'text' }]
+                },
+                variable: [{
+                    id: 'f42cc664-4823-4012-b7dd-9e9f965b736a', key: 'foo', value: 'bar', type: 'text'
+                }]
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    id: '2509a94e-eca1-43ca-a8aa-0e200636764f',
+                    auth: {
+                        type: 'bearer',
+                        bearer: [{ key: 'token', value: 'bar', type: 'string' }]
+                    },
+                    folders: [],
+                    folders_order: [],
+                    order: [],
+                    requests: [],
+                    variables: [{
+                        id: 'f42cc664-4823-4012-b7dd-9e9f965b736a', key: 'foo', value: 'bar', type: 'string'
+                    }]
+                });
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
Scope: All flows for variable(s) and auth related transformation/normalization.

Issue: The `type` field on these respective elements would be naively forwarded as is, causing schema validation to fail for converted outputs.

Fix: The `type` field described above is now converted to `string` from `text`, in order to maintain schema compliance.