### PR TITLE
Empty description handling

### DIFF
--- a/lib/converters/v1.0.0/converter-v1-to-v2.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v2.js
@@ -30,7 +30,9 @@ _.assign(Builders.prototype, {
             name: collectionV1.name
         };
 
-        collectionV1.description && (info.description = collectionV1.description);
+        if (collectionV1.description) { info.description = collectionV1.description; }
+        else if (this.options.retainEmptyValues) { info.description = null; }
+
         info.schema = constants.SCHEMA_V2_URL;
 
         return info;
@@ -61,14 +63,16 @@ _.assign(Builders.prototype, {
             traversedVars = {},
             queryParamAltered,
             traversedQueryParams = {},
-            parsed = util.urlparse(requestV1.url);
+            parsed = util.urlparse(requestV1.url),
+            retainEmpty = this.options.retainEmptyValues;
 
         // Merge query params
         _.forEach(requestV1.queryParams, function (queryParam) {
             (queryParam.enabled === false) && (queryParam.disabled = true);
 
             delete queryParam.enabled;
-            _.has(queryParam, 'description') && _.isEmpty(queryParam.description) && (delete queryParam.description);
+
+            util.cleanEmptyValue(queryParam, 'description', retainEmpty);
 
             if (_.has(queryParam, 'equals')) {
                 if (queryParam.equals) {
@@ -94,8 +98,7 @@ _.assign(Builders.prototype, {
         // Merge path variables
         _.forEach(requestV1.pathVariableData, function (pathVariable) {
             pathVariable = _.clone(pathVariable);
-            _.has(pathVariable, 'description') && _.isEmpty(pathVariable.description) &&
-                (delete pathVariable.description);
+            util.cleanEmptyValue(pathVariable, 'description', retainEmpty);
 
             pathVariables.push(pathVariable);
             traversedVars[pathVariable.key] = true;
@@ -141,7 +144,8 @@ _.assign(Builders.prototype, {
 
         var headers = [],
             traversed = {},
-            headerData = requestV1.headerData || [];
+            headerData = requestV1.headerData || [],
+            retainEmpty = this.options.retainEmptyValues;
 
         _.forEach(headerData, function (header) {
             if (_.startsWith(header.key, headersCommentPrefix) || (header.enabled === false)) {
@@ -150,7 +154,7 @@ _.assign(Builders.prototype, {
             }
 
             // prevent empty header descriptions from showing up in converted results. This keeps the collections clean
-            _.has(header, 'description') && _.isEmpty(header.description) && (delete header.description);
+            util.cleanEmptyValue(header, 'description', retainEmpty);
 
             delete header.enabled;
             headers.push(header); // @todo Improve this sequence to account for multi-valued headers
@@ -180,7 +184,8 @@ _.assign(Builders.prototype, {
                 binary: 'file'
             },
             mode,
-            data = {};
+            data = {},
+            retainEmpty = this.options.retainEmptyValues;
 
         mode = modes[requestV1.dataMode];
         !mode && (mode = 'raw');
@@ -208,7 +213,7 @@ _.assign(Builders.prototype, {
                 }
 
                 // Prevent empty descriptions from showing up in the converted results. This keeps collections clean.
-                _.has(param.description) && _.isEmpty(param.description) && (delete param.description);
+                util.cleanEmptyValue(param, 'description', retainEmpty);
 
                 delete param.enabled;
                 return param;
@@ -321,13 +326,16 @@ _.assign(Builders.prototype, {
     request: function (requestV1) {
         var self = this,
             request = {},
+            retainEmpty = self.options.retainEmptyValues,
             units = ['auth', 'method', 'header', 'body', 'url'];
 
         units.forEach(function (unit) {
             request[unit] = self[unit](requestV1);
         });
 
-        requestV1.description && (request.description = requestV1.description);
+        if (requestV1.description) { request.description = requestV1.description; }
+        else if (retainEmpty) { request.description = null; }
+
         return request;
     },
 
@@ -491,7 +499,8 @@ _.assign(Builders.prototype, {
     itemGroups: function (collectionV1) {
         var self = this,
             items = [],
-            itemGroupCache = {};
+            itemGroupCache = {},
+            retainEmpty = self.options.retainEmptyValues;
 
         // Read all folder data, and prep it so that we can throw subfolders in the right places
         itemGroupCache = _.reduce(collectionV1.folders, function (accumulator, folder) {
@@ -503,9 +512,11 @@ _.assign(Builders.prototype, {
                 result = {
                     _postman_id: self.options.retainIds && folder.id ? folder.id : util.uid(),
                     name: folder.name,
-                    description: folder.description,
                     item: []
                 };
+
+            if (folder.description) { result.description = folder.description; }
+            else if (retainEmpty) { result.description = null; }
 
             (auth || (auth === null)) && (result.auth = auth);
             event && (result.event = event);

--- a/lib/converters/v2.0.0/converter-v2-to-v1.js
+++ b/lib/converters/v2.0.0/converter-v2-to-v1.js
@@ -141,7 +141,9 @@ _.assign(Builders.prototype, {
      * @returns {*}
      */
     data: function (item) {
-        var mode = _.get(item, 'request.body.mode');
+        var mode = _.get(item, 'request.body.mode'),
+            retainEmpty = this.options.retainEmptyValues;
+
         if (mode === 'raw' || mode === 'file' || !mode) {
             return [];
         }
@@ -153,7 +155,7 @@ _.assign(Builders.prototype, {
             }
 
             // Prevents empty request body descriptions from showing up in the result, keeps collections clean.
-            _.has(elem, 'description') && _.isEmpty(elem.description) && (delete elem.description);
+            util.cleanEmptyValue(elem, 'description', retainEmpty);
             _.has(elem, 'disabled') && (elem.enabled = !elem.disabled);
 
             delete elem.disabled;
@@ -366,6 +368,7 @@ _.assign(Builders.prototype, {
             events = self.events(item),
             variables = self.variables(item),
             url = req && req.url,
+            retainEmpty = self.options.retainEmptyValues,
             urlObj = _.isString(url) ? util.urlparse(url) : url;
 
         !skipResponses && units.push('responses');
@@ -398,7 +401,8 @@ _.assign(Builders.prototype, {
         description = item.request && self.description(item.request.description);
 
         // Prevent empty request descriptions from showing up in the converted result, keeps collections clean.
-        !_.isEmpty(description) && (request.description = description);
+        if (description) { request.description = description; }
+        else if (retainEmpty) { request.description = null; }
 
         (auth || (auth === null)) && (request.auth = auth);
         events && events.length && (request.events = events);
@@ -413,14 +417,16 @@ _.assign(Builders.prototype, {
             var result = { key: v.key || v.id, value: v.value };
 
             // Prevent empty path variable descriptions from showing up in converted results, keeps collections clean.
-            !_.isEmpty(v.description) && (result.description = v.description);
+            if (v.description) { result.description = v.description; }
+            else if (retainEmpty) { result.description = null; }
 
             return result;
         }));
 
         urlObj && (request.queryParams = _.map(urlObj.query, function (queryParam) {
             // Prevents empty query param descriptions from showing up in the result, keeps collections clean.
-            _.has(queryParam, 'description') && _.isEmpty(queryParam.description) && (delete queryParam.description);
+            util.cleanEmptyValue(queryParam, 'description', retainEmpty);
+
             _.has(queryParam, 'disabled') && (queryParam.enabled = !queryParam.disabled);
             delete queryParam.disabled;
 
@@ -430,7 +436,8 @@ _.assign(Builders.prototype, {
         // item truthiness is already validated by this point
         request.headerData = _.map(item.request && (item.request.headers || item.request.header), function (header) {
             // Prevents empty query param descriptions from showing up in the result, keeps collections clean.
-            _.has(header, 'description') && _.isEmpty(header.description) && (delete header.description);
+            util.cleanEmptyValue(header, 'description', retainEmpty);
+
             _.has(header, 'disabled') && (header.enabled = !header.disabled);
             delete header.disabled;
 
@@ -500,7 +507,8 @@ _.assign(Builders.prototype, {
      * @param collectionV2
      */
     folders: function (collectionV2) {
-        var self = this;
+        var self = this,
+            retainEmpty = self.options.retainEmptyValues;
 
         return _.map(self.extractFolderItems(collectionV2), function (folder) {
             if (!folder) { return; }
@@ -528,7 +536,9 @@ _.assign(Builders.prototype, {
             variables && variables.length && (result.variables = variables);
 
             // Prevent empty folder descriptions from showing up in the result, keeps collections clean.
-            !_.isEmpty(description) && (result.description = description);
+            if (description) { result.description = description; }
+            else if (retainEmpty) { result.description = null; }
+
             return result;
         });
     },
@@ -541,10 +551,13 @@ _.assign(Builders.prototype, {
      * @returns {String=}
      */
     description: function (descriptionV2) {
-        if (_.isObject(descriptionV2) && !_.isEmpty(descriptionV2.content)) {
-            return _.isString(descriptionV2.content) ? descriptionV2.content : '';
-        }
-        return _.isString(descriptionV2) ? descriptionV2 : '';
+        var description,
+            retainEmpty = this.options.retainEmptyValues;
+
+        description = _.isObject(descriptionV2) ? descriptionV2.content : descriptionV2;
+
+        if (description) { return description; }
+        else if (retainEmpty) { return null; }
     }
 });
 
@@ -629,7 +642,6 @@ module.exports = {
         var auth,
             events,
             variables,
-            description,
             builders = new Builders(options),
             authOptions = { excludeNoauth: true },
             varOpts = { fallback: options && options.env },
@@ -644,7 +656,7 @@ module.exports = {
         collection = v2Common.populateIds(collection);
         try {
             // eslint-disable-next-line max-len
-            (description = builders.description(collection.info.description)) && (newCollection.description = description);
+            newCollection.description = builders.description(collection.info.description);
             (auth = builders.auth(collection, authOptions)) && (newCollection.auth = auth);
             (events = builders.events(collection)) && (newCollection.events = events);
             (variables = builders.variables(collection, varOpts)) && (newCollection.variables = variables);

--- a/lib/converters/v2.1.0/converter-v21-to-v1.js
+++ b/lib/converters/v2.1.0/converter-v21-to-v1.js
@@ -90,7 +90,6 @@ module.exports = {
         var auth,
             events,
             variables,
-            description,
             builders = new Builders(options),
             authOptions = { excludeNoauth: true },
             units = ['order', 'folders_order', 'folders', 'requests'],
@@ -105,7 +104,7 @@ module.exports = {
         collection = v2Common.populateIds(collection);
         try {
             // eslint-disable-next-line max-len
-            (description = builders.description(collection.info.description)) && (newCollection.description = description);
+            newCollection.description = builders.description(collection.info.description);
             (auth = builders.auth(collection, authOptions)) && (newCollection.auth = auth);
             (events = builders.events(collection)) && (newCollection.events = events);
             (variables = builders.variables(collection, varOpts)) && (newCollection.variables = variables);

--- a/lib/normalizers/v1.js
+++ b/lib/normalizers/v1.js
@@ -41,9 +41,7 @@ var _ = require('lodash').noConflict(),
         var retainEmpty = options && options.retainEmptyValues;
 
         _.forEach(entities, function (entity) {
-            if (_.has(entity, 'description') && !entity.description) {
-                retainEmpty ? (entity.description = '') : (delete entity.description);
-            }
+            util.cleanEmptyValue(entity, 'description', retainEmpty);
         });
 
         return entities;
@@ -233,9 +231,7 @@ _.assign(Builders.prototype, {
         // if id is falsy, replace the id
         // if retainIds is false, replace the id
         !((options.retainIds && requestV1.id) || options.noDefaults) && (requestV1.id = util.uid());
-        if (_.has(requestV1, 'description') && !requestV1.description) {
-            retainEmpty ? (requestV1.description = '') : (delete requestV1.description);
-        }
+        util.cleanEmptyValue(requestV1, 'description', retainEmpty);
 
         units.forEach(function (unit) {
             var result = self[unit](requestV1);
@@ -397,9 +393,7 @@ _.assign(Builders.prototype, {
             // if id is falsy, replace the id
             // if retainIds is false, replace the id
             !((self.options.retainIds && folder.id) || self.options.noDefaults) && (folder.id = util.uid());
-            if (_.has(folder, 'description') && !folder.description) {
-                retainEmpty ? (folder.description = '') : (delete folder.description);
-            }
+            util.cleanEmptyValue(folder, 'description', retainEmpty);
 
             auth = self.auth(folder);
 
@@ -529,11 +523,9 @@ module.exports = {
         // if retainIds is false, replace the id
         !((options.retainIds && collection.id) || options.noDefaults) && (collection.id = util.uid());
 
-        try {
-            if (_.has(collection, 'description') && !collection.description) {
-                retainEmpty ? (collection.description = '') : (delete collection.description);
-            }
+        util.cleanEmptyValue(collection, 'description', retainEmpty);
 
+        try {
             (auth = builders.auth(collection, authOptions)) ? (collection.auth = auth) : (delete collection.auth);
 
             units.forEach(function (unit) {

--- a/lib/normalizers/v1.js
+++ b/lib/normalizers/v1.js
@@ -188,14 +188,16 @@ _.assign(Builders.prototype, {
      * Facilitates sanitized variable transformations across all levels for v1 collection normalization.
      *
      * @param {Object} entity - The wrapper object containing variable definitions.
-     * @param {?Object} options - The set of options for the current variable transformation.
-     * @param {?Object} options.fallback - The set of fallback values to be applied when no variables exist.
-     * @param {?Boolean} options.noDefaults - When set to true, no defaults are applied.
-     * @param {?Boolean} options.retainIds - When set to true, ids are left as is.
+     * @param {?Object} [options] - The set of options for the current variable transformation.
+     * @param {?Object} [options.fallback] - The set of fallback values to be applied when no variables exist.
+     * @param {?Boolean} [options.noDefaults] - When set to true, no defaults are applied.
+     * @param {?Boolean} [options.retainEmptyValues] - When set to true, empty values are set to null instead of being
+     * removed.
+     * @param {?Boolean} [options.retainIds] - When set to true, ids are left as is.
      * @returns {Object[]} - The set of sanitized variables.
      */
     pathVariableData: function (entity, options) {
-        return util.handleVars(entity, options);
+        return util.handleVars(entity, options, true);
     },
 
     /**
@@ -234,7 +236,8 @@ _.assign(Builders.prototype, {
         util.cleanEmptyValue(requestV1, 'description', retainEmpty);
 
         units.forEach(function (unit) {
-            var result = self[unit](requestV1);
+            var result = self[unit](requestV1, self.options);
+
             result && (requestV1[unit] = result);
         });
 

--- a/lib/normalizers/v1.js
+++ b/lib/normalizers/v1.js
@@ -197,7 +197,7 @@ _.assign(Builders.prototype, {
      * @returns {Object[]} - The set of sanitized variables.
      */
     pathVariableData: function (entity, options) {
-        return util.handleVars(entity, options, true);
+        return util.handleVars(entity, options, { isV1: true });
     },
 
     /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -50,14 +50,16 @@ util = {
      * @param {?Boolean} options.noDefaults - When set to true, id will be retained.
      * @param {?Boolean} options.retainEmptyValues - When set to true, empty property values will be set to ''
      * instead of being deleted.
-     * @param {Boolean} [isV1=false] - When set to true, looks for the pathVariableData property as well.
+     * @param {Object} [modifiers] - A set of behavioral modifiers for variable handling.
+     * @param {Boolean} [modifiers.isV1=false] - When set to true, looks for the pathVariableData property as well.
      * @return {Array} - The set of sanitized entity level variables.
      */
-    handleVars: function (entity, options, isV1) {
+    handleVars: function (entity, options, modifiers) {
         !options && (options = {});
 
         var self = this,
             noDefaults = options.noDefaults,
+            isV1 = modifiers && modifiers.isV1,
             retainEmpty = options.retainEmptyValues,
             source = entity && (entity.variables || entity.variable || (isV1 && entity.pathVariableData)),
             fallback = options.fallback && options.fallback.values,

--- a/lib/util.js
+++ b/lib/util.js
@@ -50,15 +50,16 @@ util = {
      * @param {?Boolean} options.noDefaults - When set to true, id will be retained.
      * @param {?Boolean} options.retainEmptyValues - When set to true, empty property values will be set to ''
      * instead of being deleted.
+     * @param {Boolean} [isV1=false] - When set to true, looks for the pathVariableData property as well.
      * @return {Array} - The set of sanitized entity level variables.
      */
-    handleVars: function (entity, options) {
+    handleVars: function (entity, options, isV1) {
         !options && (options = {});
 
         var self = this,
             noDefaults = options.noDefaults,
             retainEmpty = options.retainEmptyValues,
-            source = entity && (entity.variables || entity.variable),
+            source = entity && (entity.variables || entity.variable || (isV1 && entity.pathVariableData)),
             fallback = options.fallback && options.fallback.values,
             result = _.map(source || fallback, function (item) {
                 var result = {
@@ -69,6 +70,7 @@ util = {
                 };
 
                 item.disabled && (result.disabled = true);
+
                 if (item.description) { result.description = item.description; }
                 else if (retainEmpty) { result.description = null; }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -69,9 +69,8 @@ util = {
                 };
 
                 item.disabled && (result.disabled = true);
-                if (_.has(item, 'description')) {
-                    result.description = (item.description || !retainEmpty) ? item.description : '';
-                }
+                if (item.description) { result.description = item.description; }
+                else if (retainEmpty) { result.description = null; }
 
                 return result;
             });
@@ -99,6 +98,14 @@ util = {
         }
 
         return auth;
+    },
+
+    cleanEmptyValue: function (entity, property, retainEmpty) {
+        if (_.has(entity, property) && !entity[property]) {
+            retainEmpty ? (entity[property] = null) : (delete entity[property]);
+        }
+
+        return entity;
     },
 
     /**

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -1809,4 +1809,93 @@ describe('v1.0.0 to v2.0.0', function () {
             });
         });
     });
+
+    describe('retainEmptyValues', function () {
+        var options = {
+            inputVersion: '1.0.0',
+            outputVersion: '2.0.0',
+            retainIds: true,
+            retainEmptyValues: true
+        };
+
+        it('should nullify empty descriptions when set to true', function () {
+            transformer.convert({
+                id: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
+                description: '', // this represents the case where descriptions are removed
+                folders: [{
+                    id: 'f3285fa0-e361-43ba-ba15-618c7a911e84',
+                    description: null,
+                    order: ['9d123ce5-314a-40cd-9852-6a8569513f4e']
+                }],
+                requests: [{
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                    description: false,
+                    dataMode: 'formdata',
+                    data: [{ key: 'body_foo', value: 'body_bar', description: 0 }],
+                    auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random' }] },
+                    headerData: [{ key: 'header_foo', value: 'header_bar', description: undefined }],
+                    queryParams: [{ key: 'query_foo', value: 'query_bar', description: NaN }]
+                }]
+            }, options, function (err, result) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    info: {
+                        _postman_id: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
+                        description: null,
+                        schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+                    },
+                    item: [{
+                        _postman_id: 'f3285fa0-e361-43ba-ba15-618c7a911e84',
+                        item: [{
+                            _postman_id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                            name: '',
+                            request: {
+                                auth: { type: 'bearer', bearer: { token: 'random' } },
+                                description: null,
+                                body: { mode: 'raw', raw: '' },
+                                header: [{ description: null, key: 'header_foo', value: 'header_bar' }],
+                                url: {
+                                    query: [{ description: null, key: 'query_foo', value: 'query_bar' }],
+                                    raw: ''
+                                }
+                            },
+                            response: []
+                        }],
+                        description: null
+                    }]
+                });
+            });
+        });
+
+        it('should nullify empty descriptions in requests when set to true', function () {
+            transformer.convertSingle({
+                id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                description: false,
+                dataMode: 'formdata',
+                data: [{ key: 'body_foo', value: 'body_bar', description: 0 }],
+                auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random' }] },
+                headerData: [{ key: 'header_foo', value: 'header_bar', description: undefined }],
+                queryParams: [{ key: 'query_foo', value: 'query_bar', description: NaN }]
+            }, options, function (err, result) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    _postman_id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                    name: '',
+                    request: {
+                        auth: { type: 'bearer', bearer: { token: 'random' } },
+                        body: { mode: 'raw', raw: '' },
+                        description: null,
+                        header: [{ description: null, key: 'header_foo', value: 'header_bar' }],
+                        url: {
+                            query: [{ description: null, key: 'query_foo', value: 'query_bar' }],
+                            raw: ''
+                        }
+                    },
+                    response: []
+                });
+            });
+        });
+    });
 });

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -1830,9 +1830,10 @@ describe('v1.0.0 to v2.0.0', function () {
                 requests: [{
                     id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
                     description: false,
-                    dataMode: 'formdata',
+                    dataMode: 'params',
                     data: [{ key: 'body_foo', value: 'body_bar', description: 0 }],
                     auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random' }] },
+                    pathVariableData: [{ key: 'pv_foo', value: 'pv_bar', description: '' }],
                     headerData: [{ key: 'header_foo', value: 'header_bar', description: undefined }],
                     queryParams: [{ key: 'query_foo', value: 'query_bar', description: NaN }]
                 }]
@@ -1853,11 +1854,15 @@ describe('v1.0.0 to v2.0.0', function () {
                             request: {
                                 auth: { type: 'bearer', bearer: { token: 'random' } },
                                 description: null,
-                                body: { mode: 'raw', raw: '' },
+                                body: {
+                                    mode: 'formdata',
+                                    formdata: [{ description: null, key: 'body_foo', value: 'body_bar' }]
+                                },
                                 header: [{ description: null, key: 'header_foo', value: 'header_bar' }],
                                 url: {
                                     query: [{ description: null, key: 'query_foo', value: 'query_bar' }],
-                                    raw: ''
+                                    raw: '',
+                                    variable: [{ description: null, key: 'pv_foo', value: 'pv_bar' }]
                                 }
                             },
                             response: []
@@ -1872,9 +1877,10 @@ describe('v1.0.0 to v2.0.0', function () {
             transformer.convertSingle({
                 id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
                 description: false,
-                dataMode: 'formdata',
+                dataMode: 'params',
                 data: [{ key: 'body_foo', value: 'body_bar', description: 0 }],
                 auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random' }] },
+                pathVariableData: [{ key: 'pv_foo', value: 'pv_bar', description: '' }],
                 headerData: [{ key: 'header_foo', value: 'header_bar', description: undefined }],
                 queryParams: [{ key: 'query_foo', value: 'query_bar', description: NaN }]
             }, options, function (err, result) {
@@ -1885,12 +1891,51 @@ describe('v1.0.0 to v2.0.0', function () {
                     name: '',
                     request: {
                         auth: { type: 'bearer', bearer: { token: 'random' } },
-                        body: { mode: 'raw', raw: '' },
+                        body: {
+                            mode: 'formdata',
+                            formdata: [{ description: null, key: 'body_foo', value: 'body_bar' }]
+                        },
                         description: null,
                         header: [{ description: null, key: 'header_foo', value: 'header_bar' }],
                         url: {
                             query: [{ description: null, key: 'query_foo', value: 'query_bar' }],
-                            raw: ''
+                            raw: '',
+                            variable: [{ description: null, key: 'pv_foo', value: 'pv_bar' }]
+                        }
+                    },
+                    response: []
+                });
+            });
+        });
+
+        it('should work correctly for urlencoded bodies as well', function () {
+            transformer.convertSingle({
+                id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                description: false,
+                dataMode: 'urlencoded',
+                data: [{ key: 'body_foo', value: 'body_bar', description: 0 }],
+                auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random' }] },
+                pathVariableData: [{ key: 'pv_foo', value: 'pv_bar', description: '' }],
+                headerData: [{ key: 'header_foo', value: 'header_bar', description: undefined }],
+                queryParams: [{ key: 'query_foo', value: 'query_bar', description: NaN }]
+            }, options, function (err, result) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    _postman_id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                    name: '',
+                    request: {
+                        auth: { type: 'bearer', bearer: { token: 'random' } },
+                        body: {
+                            mode: 'urlencoded',
+                            urlencoded: [{ description: null, key: 'body_foo', value: 'body_bar' }]
+                        },
+                        description: null,
+                        header: [{ description: null, key: 'header_foo', value: 'header_bar' }],
+                        url: {
+                            query: [{ description: null, key: 'query_foo', value: 'query_bar' }],
+                            raw: '',
+                            variable: [{ description: null, key: 'pv_foo', value: 'pv_bar' }]
                         }
                     },
                     response: []

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -1818,4 +1818,93 @@ describe('v1.0.0 to v2.1.0', function () {
             });
         });
     });
+
+    describe('retainEmptyValues', function () {
+        var options = {
+            inputVersion: '1.0.0',
+            outputVersion: '2.1.0',
+            retainIds: true,
+            retainEmptyValues: true
+        };
+
+        it('should nullify empty descriptions when set to true', function () {
+            transformer.convert({
+                id: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
+                description: '', // this represents the case where descriptions are removed
+                folders: [{
+                    id: 'f3285fa0-e361-43ba-ba15-618c7a911e84',
+                    description: null,
+                    order: ['9d123ce5-314a-40cd-9852-6a8569513f4e']
+                }],
+                requests: [{
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                    description: false,
+                    dataMode: 'formdata',
+                    data: [{ key: 'body_foo', value: 'body_bar', description: 0 }],
+                    auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random' }] },
+                    headerData: [{ key: 'header_foo', value: 'header_bar', description: undefined }],
+                    queryParams: [{ key: 'query_foo', value: 'query_bar', description: NaN }]
+                }]
+            }, options, function (err, result) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    info: {
+                        _postman_id: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
+                        description: null,
+                        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+                    },
+                    item: [{
+                        _postman_id: 'f3285fa0-e361-43ba-ba15-618c7a911e84',
+                        item: [{
+                            _postman_id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                            name: '',
+                            request: {
+                                auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
+                                description: null,
+                                body: { mode: 'raw', raw: '' },
+                                header: [{ description: null, key: 'header_foo', value: 'header_bar' }],
+                                url: {
+                                    query: [{ description: null, key: 'query_foo', value: 'query_bar' }],
+                                    raw: ''
+                                }
+                            },
+                            response: []
+                        }],
+                        description: null
+                    }]
+                });
+            });
+        });
+
+        it('should nullify empty descriptions in requests when set to true', function () {
+            transformer.convertSingle({
+                id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                description: false,
+                dataMode: 'formdata',
+                data: [{ key: 'body_foo', value: 'body_bar', description: 0 }],
+                auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random' }] },
+                headerData: [{ key: 'header_foo', value: 'header_bar', description: undefined }],
+                queryParams: [{ key: 'query_foo', value: 'query_bar', description: NaN }]
+            }, options, function (err, result) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    _postman_id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                    name: '',
+                    request: {
+                        auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
+                        body: { mode: 'raw', raw: '' },
+                        description: null,
+                        header: [{ description: null, key: 'header_foo', value: 'header_bar' }],
+                        url: {
+                            query: [{ description: null, key: 'query_foo', value: 'query_bar' }],
+                            raw: ''
+                        }
+                    },
+                    response: []
+                });
+            });
+        });
+    });
 });

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -1839,9 +1839,10 @@ describe('v1.0.0 to v2.1.0', function () {
                 requests: [{
                     id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
                     description: false,
-                    dataMode: 'formdata',
+                    dataMode: 'params',
                     data: [{ key: 'body_foo', value: 'body_bar', description: 0 }],
                     auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random' }] },
+                    pathVariableData: [{ key: 'pv_foo', value: 'pv_bar', description: '' }],
                     headerData: [{ key: 'header_foo', value: 'header_bar', description: undefined }],
                     queryParams: [{ key: 'query_foo', value: 'query_bar', description: NaN }]
                 }]
@@ -1862,11 +1863,15 @@ describe('v1.0.0 to v2.1.0', function () {
                             request: {
                                 auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
                                 description: null,
-                                body: { mode: 'raw', raw: '' },
+                                body: {
+                                    mode: 'formdata',
+                                    formdata: [{ description: null, key: 'body_foo', value: 'body_bar' }]
+                                },
                                 header: [{ description: null, key: 'header_foo', value: 'header_bar' }],
                                 url: {
                                     query: [{ description: null, key: 'query_foo', value: 'query_bar' }],
-                                    raw: ''
+                                    raw: '',
+                                    variable: [{ description: null, key: 'pv_foo', value: 'pv_bar' }]
                                 }
                             },
                             response: []
@@ -1881,9 +1886,10 @@ describe('v1.0.0 to v2.1.0', function () {
             transformer.convertSingle({
                 id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
                 description: false,
-                dataMode: 'formdata',
+                dataMode: 'params',
                 data: [{ key: 'body_foo', value: 'body_bar', description: 0 }],
                 auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random' }] },
+                pathVariableData: [{ key: 'pv_foo', value: 'pv_bar', description: '' }],
                 headerData: [{ key: 'header_foo', value: 'header_bar', description: undefined }],
                 queryParams: [{ key: 'query_foo', value: 'query_bar', description: NaN }]
             }, options, function (err, result) {
@@ -1894,12 +1900,51 @@ describe('v1.0.0 to v2.1.0', function () {
                     name: '',
                     request: {
                         auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
-                        body: { mode: 'raw', raw: '' },
+                        body: {
+                            mode: 'formdata',
+                            formdata: [{ description: null, key: 'body_foo', value: 'body_bar' }]
+                        },
                         description: null,
                         header: [{ description: null, key: 'header_foo', value: 'header_bar' }],
                         url: {
                             query: [{ description: null, key: 'query_foo', value: 'query_bar' }],
-                            raw: ''
+                            raw: '',
+                            variable: [{ description: null, key: 'pv_foo', value: 'pv_bar' }]
+                        }
+                    },
+                    response: []
+                });
+            });
+        });
+
+        it('should work correctly for urlencoded values as well', function () {
+            transformer.convertSingle({
+                id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                description: false,
+                dataMode: 'urlencoded',
+                data: [{ key: 'body_foo', value: 'body_bar', description: 0 }],
+                auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random' }] },
+                pathVariableData: [{ key: 'pv_foo', value: 'pv_bar', description: '' }],
+                headerData: [{ key: 'header_foo', value: 'header_bar', description: undefined }],
+                queryParams: [{ key: 'query_foo', value: 'query_bar', description: NaN }]
+            }, options, function (err, result) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    _postman_id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                    name: '',
+                    request: {
+                        auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
+                        body: {
+                            mode: 'urlencoded',
+                            urlencoded: [{ description: null, key: 'body_foo', value: 'body_bar' }]
+                        },
+                        description: null,
+                        header: [{ description: null, key: 'header_foo', value: 'header_bar' }],
+                        url: {
+                            query: [{ description: null, key: 'query_foo', value: 'query_bar' }],
+                            raw: '',
+                            variable: [{ description: null, key: 'pv_foo', value: 'pv_bar' }]
                         }
                     },
                     response: []

--- a/test/unit/v1.0.0/normalize-v1.test.js
+++ b/test/unit/v1.0.0/normalize-v1.test.js
@@ -1713,7 +1713,6 @@ describe('v1.0.0 normalization', function () {
                 }]
             }, options, function (err, result) {
                 expect(err).to.not.be.ok;
-                console.log(result);
                 expect(result).to.eql({
                     id: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
                     description: null,

--- a/test/unit/v1.0.0/normalize-v1.test.js
+++ b/test/unit/v1.0.0/normalize-v1.test.js
@@ -1714,18 +1714,18 @@ describe('v1.0.0 normalization', function () {
                 expect(err).to.not.be.ok;
                 expect(result).to.eql({
                     id: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
-                    description: '',
-                    folders: [{ id: 'f3285fa0-e361-43ba-ba15-618c7a911e84', description: '' }],
+                    description: null,
+                    folders: [{ id: 'f3285fa0-e361-43ba-ba15-618c7a911e84', description: null }],
                     requests: [{
                         id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
-                        description: '',
+                        description: null,
                         dataMode: 'formdata',
-                        data: [{ key: 'body_foo', value: 'body_bar', description: '' }],
+                        data: [{ key: 'body_foo', value: 'body_bar', description: null }],
                         auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
                         currentHelper: 'bearerAuth',
                         helperAttributes: { id: 'bearer', token: 'random' },
-                        headerData: [{ key: 'header_foo', value: 'header_bar', description: '' }],
-                        queryParams: [{ key: 'query_foo', value: 'query_bar', description: '' }]
+                        headerData: [{ key: 'header_foo', value: 'header_bar', description: null }],
+                        queryParams: [{ key: 'query_foo', value: 'query_bar', description: null }]
                     }]
                 });
             });
@@ -1744,14 +1744,14 @@ describe('v1.0.0 normalization', function () {
                 expect(err).to.not.be.ok;
                 expect(result).to.eql({
                     id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
-                    description: '',
+                    description: null,
                     dataMode: 'formdata',
-                    data: [{ key: 'body_foo', value: 'body_bar', description: '' }],
+                    data: [{ key: 'body_foo', value: 'body_bar', description: null }],
                     auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
                     currentHelper: 'bearerAuth',
                     helperAttributes: { id: 'bearer', token: 'random' },
-                    headerData: [{ key: 'header_foo', value: 'header_bar', description: '' }],
-                    queryParams: [{ key: 'query_foo', value: 'query_bar', description: '' }]
+                    headerData: [{ key: 'header_foo', value: 'header_bar', description: null }],
+                    queryParams: [{ key: 'query_foo', value: 'query_bar', description: null }]
                 });
             });
         });

--- a/test/unit/v1.0.0/normalize-v1.test.js
+++ b/test/unit/v1.0.0/normalize-v1.test.js
@@ -1704,14 +1704,16 @@ describe('v1.0.0 normalization', function () {
                 requests: [{
                     id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
                     description: false,
-                    dataMode: 'formdata',
+                    dataMode: 'params',
                     data: [{ key: 'body_foo', value: 'body_bar', description: 0 }],
                     auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random' }] },
+                    pathVariableData: [{ id: 'pv1', key: 'pv_foo', value: 'pv_bar', description: '' }],
                     headerData: [{ key: 'header_foo', value: 'header_bar', description: undefined }],
                     queryParams: [{ key: 'query_foo', value: 'query_bar', description: NaN }]
                 }]
             }, options, function (err, result) {
                 expect(err).to.not.be.ok;
+                console.log(result);
                 expect(result).to.eql({
                     id: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
                     description: null,
@@ -1719,13 +1721,16 @@ describe('v1.0.0 normalization', function () {
                     requests: [{
                         id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
                         description: null,
-                        dataMode: 'formdata',
+                        dataMode: 'params',
                         data: [{ key: 'body_foo', value: 'body_bar', description: null }],
                         auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
                         currentHelper: 'bearerAuth',
                         helperAttributes: { id: 'bearer', token: 'random' },
                         headerData: [{ key: 'header_foo', value: 'header_bar', description: null }],
-                        queryParams: [{ key: 'query_foo', value: 'query_bar', description: null }]
+                        queryParams: [{ key: 'query_foo', value: 'query_bar', description: null }],
+                        pathVariableData: [{
+                            id: 'pv1', key: 'pv_foo', value: 'pv_bar', description: null, type: 'string'
+                        }]
                     }]
                 });
             });
@@ -1735,9 +1740,10 @@ describe('v1.0.0 normalization', function () {
             transformer.normalizeSingle({
                 id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
                 description: false,
-                dataMode: 'formdata',
+                dataMode: 'params',
                 data: [{ key: 'body_foo', value: 'body_bar', description: 0 }],
                 auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random' }] },
+                pathVariableData: [{ id: 'pv1', key: 'pv_foo', value: 'pv_bar', description: '' }],
                 headerData: [{ key: 'header_foo', value: 'header_bar', description: undefined }],
                 queryParams: [{ key: 'query_foo', value: 'query_bar', description: NaN }]
             }, options, function (err, result) {
@@ -1745,13 +1751,41 @@ describe('v1.0.0 normalization', function () {
                 expect(result).to.eql({
                     id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
                     description: null,
-                    dataMode: 'formdata',
+                    dataMode: 'params',
                     data: [{ key: 'body_foo', value: 'body_bar', description: null }],
                     auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
                     currentHelper: 'bearerAuth',
                     helperAttributes: { id: 'bearer', token: 'random' },
                     headerData: [{ key: 'header_foo', value: 'header_bar', description: null }],
-                    queryParams: [{ key: 'query_foo', value: 'query_bar', description: null }]
+                    queryParams: [{ key: 'query_foo', value: 'query_bar', description: null }],
+                    pathVariableData: [{ id: 'pv1', key: 'pv_foo', value: 'pv_bar', description: null, type: 'string' }]
+                });
+            });
+        });
+
+        it('should work correctly for urlencoded bodies as well', function () {
+            transformer.normalizeSingle({
+                id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                description: false,
+                dataMode: 'urlencoded',
+                data: [{ key: 'body_foo', value: 'body_bar', description: 0 }],
+                auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random' }] },
+                pathVariableData: [{ id: 'pv1', key: 'pv_foo', value: 'pv_bar', description: '' }],
+                headerData: [{ key: 'header_foo', value: 'header_bar', description: undefined }],
+                queryParams: [{ key: 'query_foo', value: 'query_bar', description: NaN }]
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(result).to.eql({
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                    description: null,
+                    dataMode: 'urlencoded',
+                    data: [{ key: 'body_foo', value: 'body_bar', description: null }],
+                    auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
+                    currentHelper: 'bearerAuth',
+                    helperAttributes: { id: 'bearer', token: 'random' },
+                    headerData: [{ key: 'header_foo', value: 'header_bar', description: null }],
+                    queryParams: [{ key: 'query_foo', value: 'query_bar', description: null }],
+                    pathVariableData: [{ id: 'pv1', key: 'pv_foo', value: 'pv_bar', description: null, type: 'string' }]
                 });
             });
         });

--- a/test/unit/v2.0.0/converter-v2-to-v1.test.js
+++ b/test/unit/v2.0.0/converter-v2-to-v1.test.js
@@ -629,11 +629,15 @@ describe('v2.0.0 to v1.0.0', function () {
                         request: {
                             auth: { type: 'bearer', bearer: { token: 'random' } },
                             description: '',
-                            body: { mode: 'raw', raw: '' },
+                            body: {
+                                mode: 'formdata',
+                                formdata: [{ description: undefined, key: 'body_foo', value: 'body_bar' }]
+                            },
                             header: [{ description: NaN, key: 'header_foo', value: 'header_bar' }],
                             url: {
                                 query: [{ description: false, key: 'query_foo', value: 'query_bar' }],
-                                raw: ''
+                                raw: '',
+                                variable: [{ description: '', key: 'pv_foo', value: 'pv_bar' }]
                             }
                         },
                         response: []
@@ -657,13 +661,14 @@ describe('v2.0.0 to v1.0.0', function () {
                         id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
                         collectionId: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
                         description: null,
-                        dataMode: 'raw',
+                        dataMode: 'params',
                         name: '',
-                        pathVariableData: [],
+                        pathVariables: { pv_foo: 'pv_bar' },
+                        pathVariableData: [{ description: null, key: 'pv_foo', value: 'pv_bar' }],
                         rawModeData: '',
                         responses: [],
                         url: '?query_foo=query_bar',
-                        data: [],
+                        data: [{ description: null, key: 'body_foo', value: 'body_bar' }],
                         headers: 'header_foo: header_bar',
                         currentHelper: 'bearerAuth',
                         helperAttributes: { id: 'bearer', token: 'random' },
@@ -682,9 +687,14 @@ describe('v2.0.0 to v1.0.0', function () {
                     auth: { type: 'bearer', bearer: { token: 'random' } },
                     description: null,
                     header: [{ description: NaN, key: 'header_foo', value: 'header_bar' }],
+                    body: {
+                        mode: 'formdata',
+                        formdata: [{ description: undefined, key: 'body_foo', value: 'body_bar' }]
+                    },
                     url: {
                         query: [{ description: undefined, key: 'query_foo', value: 'query_bar' }],
-                        raw: ''
+                        raw: '',
+                        variable: [{ description: '', key: 'pv_foo', value: 'pv_bar' }]
                     }
                 },
                 response: []
@@ -694,8 +704,51 @@ describe('v2.0.0 to v1.0.0', function () {
                 expect(JSON.parse(JSON.stringify(result))).to.eql({
                     id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
                     description: null,
-                    data: [],
-                    pathVariableData: [],
+                    dataMode: 'params',
+                    data: [{ description: null, key: 'body_foo', value: 'body_bar' }],
+                    pathVariables: { pv_foo: 'pv_bar' },
+                    pathVariableData: [{ description: null, key: 'pv_foo', value: 'pv_bar' }],
+                    responses: [],
+                    currentHelper: 'bearerAuth',
+                    helperAttributes: { id: 'bearer', token: 'random' },
+                    auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
+                    headers: 'header_foo: header_bar',
+                    url: '?query_foo=query_bar',
+                    rawModeData: '',
+                    headerData: [{ key: 'header_foo', value: 'header_bar', description: null }],
+                    queryParams: [{ key: 'query_foo', value: 'query_bar', description: null }]
+                });
+            });
+        });
+
+        it('should work correctly for urlencoded bodies as well', function () {
+            transformer.convertSingle({
+                _postman_id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                request: {
+                    auth: { type: 'bearer', bearer: { token: 'random' } },
+                    description: null,
+                    header: [{ description: NaN, key: 'header_foo', value: 'header_bar' }],
+                    body: {
+                        mode: 'urlencoded',
+                        urlencoded: [{ description: undefined, key: 'body_foo', value: 'body_bar' }]
+                    },
+                    url: {
+                        query: [{ description: undefined, key: 'query_foo', value: 'query_bar' }],
+                        raw: '',
+                        variable: [{ description: '', key: 'pv_foo', value: 'pv_bar' }]
+                    }
+                },
+                response: []
+            }, options, function (err, result) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                    description: null,
+                    dataMode: 'urlencoded',
+                    data: [{ description: null, key: 'body_foo', value: 'body_bar' }],
+                    pathVariables: { pv_foo: 'pv_bar' },
+                    pathVariableData: [{ description: null, key: 'pv_foo', value: 'pv_bar' }],
                     responses: [],
                     currentHelper: 'bearerAuth',
                     helperAttributes: { id: 'bearer', token: 'random' },

--- a/test/unit/v2.0.0/converter-v2-to-v1.test.js
+++ b/test/unit/v2.0.0/converter-v2-to-v1.test.js
@@ -605,4 +605,108 @@ describe('v2.0.0 to v1.0.0', function () {
             });
         });
     });
+
+    describe('retainEmptyValues', function () {
+        var options = {
+            inputVersion: '2.0.0',
+            outputVersion: '1.0.0',
+            retainIds: true,
+            retainEmptyValues: true
+        };
+
+        it('should nullify empty descriptions in when set to true', function () {
+            transformer.convert({
+                info: {
+                    _postman_id: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
+                    description: 0,
+                    schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+                },
+                item: [{
+                    _postman_id: 'f3285fa0-e361-43ba-ba15-618c7a911e84',
+                    item: [{
+                        _postman_id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                        name: '',
+                        request: {
+                            auth: { type: 'bearer', bearer: { token: 'random' } },
+                            description: '',
+                            body: { mode: 'raw', raw: '' },
+                            header: [{ description: NaN, key: 'header_foo', value: 'header_bar' }],
+                            url: {
+                                query: [{ description: false, key: 'query_foo', value: 'query_bar' }],
+                                raw: ''
+                            }
+                        },
+                        response: []
+                    }],
+                    description: undefined
+                }]
+            }, options, function (err, result) {
+                expect(err).not.to.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    id: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
+                    description: null, // this represents the case where descriptions are removed
+                    order: [],
+                    folders_order: ['f3285fa0-e361-43ba-ba15-618c7a911e84'],
+                    folders: [{
+                        id: 'f3285fa0-e361-43ba-ba15-618c7a911e84',
+                        description: null,
+                        folders_order: [],
+                        order: ['9d123ce5-314a-40cd-9852-6a8569513f4e']
+                    }],
+                    requests: [{
+                        id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                        collectionId: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
+                        description: null,
+                        dataMode: 'raw',
+                        name: '',
+                        pathVariableData: [],
+                        rawModeData: '',
+                        responses: [],
+                        url: '?query_foo=query_bar',
+                        data: [],
+                        headers: 'header_foo: header_bar',
+                        currentHelper: 'bearerAuth',
+                        helperAttributes: { id: 'bearer', token: 'random' },
+                        auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
+                        headerData: [{ key: 'header_foo', value: 'header_bar', description: null }],
+                        queryParams: [{ key: 'query_foo', value: 'query_bar', description: null }]
+                    }]
+                });
+            });
+        });
+
+        it('should nullify empty descriptions in requests when set to true', function () {
+            transformer.convertSingle({
+                _postman_id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                request: {
+                    auth: { type: 'bearer', bearer: { token: 'random' } },
+                    description: null,
+                    header: [{ description: NaN, key: 'header_foo', value: 'header_bar' }],
+                    url: {
+                        query: [{ description: undefined, key: 'query_foo', value: 'query_bar' }],
+                        raw: ''
+                    }
+                },
+                response: []
+            }, options, function (err, result) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                    description: null,
+                    data: [],
+                    pathVariableData: [],
+                    responses: [],
+                    currentHelper: 'bearerAuth',
+                    helperAttributes: { id: 'bearer', token: 'random' },
+                    auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
+                    headers: 'header_foo: header_bar',
+                    url: '?query_foo=query_bar',
+                    rawModeData: '',
+                    headerData: [{ key: 'header_foo', value: 'header_bar', description: null }],
+                    queryParams: [{ key: 'query_foo', value: 'query_bar', description: null }]
+                });
+            });
+        });
+    });
 });

--- a/test/unit/v2.1.0/converter-v21-to-v1.test.js
+++ b/test/unit/v2.1.0/converter-v21-to-v1.test.js
@@ -631,11 +631,15 @@ describe('v2.1.0 to v1.0.0', function () {
                         request: {
                             auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
                             description: '',
-                            body: { mode: 'raw', raw: '' },
+                            body: {
+                                mode: 'formdata',
+                                formdata: [{ description: undefined, key: 'body_foo', value: 'body_bar' }]
+                            },
                             header: [{ description: NaN, key: 'header_foo', value: 'header_bar' }],
                             url: {
                                 query: [{ description: false, key: 'query_foo', value: 'query_bar' }],
-                                raw: ''
+                                raw: '',
+                                variable: [{ description: '', key: 'pv_foo', value: 'pv_bar' }]
                             }
                         },
                         response: []
@@ -659,13 +663,14 @@ describe('v2.1.0 to v1.0.0', function () {
                         id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
                         collectionId: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
                         description: null,
-                        dataMode: 'raw',
+                        dataMode: 'params',
                         name: '',
-                        pathVariableData: [],
+                        pathVariables: { pv_foo: 'pv_bar' },
+                        pathVariableData: [{ description: null, key: 'pv_foo', value: 'pv_bar' }],
                         rawModeData: '',
                         responses: [],
                         url: '?query_foo=query_bar',
-                        data: [],
+                        data: [{ description: null, key: 'body_foo', value: 'body_bar' }],
                         headers: 'header_foo: header_bar',
                         currentHelper: 'bearerAuth',
                         helperAttributes: { id: 'bearer', token: 'random' },
@@ -683,10 +688,15 @@ describe('v2.1.0 to v1.0.0', function () {
                 request: {
                     auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
                     description: null,
+                    body: {
+                        mode: 'formdata',
+                        formdata: [{ description: undefined, key: 'body_foo', value: 'body_bar' }]
+                    },
                     header: [{ description: NaN, key: 'header_foo', value: 'header_bar' }],
                     url: {
                         query: [{ description: undefined, key: 'query_foo', value: 'query_bar' }],
-                        raw: ''
+                        raw: '',
+                        variable: [{ description: '', key: 'pv_foo', value: 'pv_bar' }]
                     }
                 },
                 response: []
@@ -696,8 +706,51 @@ describe('v2.1.0 to v1.0.0', function () {
                 expect(JSON.parse(JSON.stringify(result))).to.eql({
                     id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
                     description: null,
-                    data: [],
-                    pathVariableData: [],
+                    dataMode: 'params',
+                    data: [{ description: null, key: 'body_foo', value: 'body_bar' }],
+                    pathVariables: { pv_foo: 'pv_bar' },
+                    pathVariableData: [{ description: null, key: 'pv_foo', value: 'pv_bar' }],
+                    responses: [],
+                    currentHelper: 'bearerAuth',
+                    helperAttributes: { id: 'bearer', token: 'random' },
+                    auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
+                    headers: 'header_foo: header_bar',
+                    url: '?query_foo=query_bar',
+                    rawModeData: '',
+                    headerData: [{ key: 'header_foo', value: 'header_bar', description: null }],
+                    queryParams: [{ key: 'query_foo', value: 'query_bar', description: null }]
+                });
+            });
+        });
+
+        it('should work correctly for urlencoded bodies as well', function () {
+            transformer.convertSingle({
+                _postman_id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                request: {
+                    auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
+                    description: null,
+                    body: {
+                        mode: 'urlencoded',
+                        urlencoded: [{ description: undefined, key: 'body_foo', value: 'body_bar' }]
+                    },
+                    header: [{ description: NaN, key: 'header_foo', value: 'header_bar' }],
+                    url: {
+                        query: [{ description: undefined, key: 'query_foo', value: 'query_bar' }],
+                        raw: '',
+                        variable: [{ description: '', key: 'pv_foo', value: 'pv_bar' }]
+                    }
+                },
+                response: []
+            }, options, function (err, result) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                    description: null,
+                    dataMode: 'urlencoded',
+                    data: [{ description: null, key: 'body_foo', value: 'body_bar' }],
+                    pathVariables: { pv_foo: 'pv_bar' },
+                    pathVariableData: [{ description: null, key: 'pv_foo', value: 'pv_bar' }],
                     responses: [],
                     currentHelper: 'bearerAuth',
                     helperAttributes: { id: 'bearer', token: 'random' },

--- a/test/unit/v2.1.0/converter-v21-to-v1.test.js
+++ b/test/unit/v2.1.0/converter-v21-to-v1.test.js
@@ -607,4 +607,108 @@ describe('v2.1.0 to v1.0.0', function () {
             });
         });
     });
+
+    describe('retainEmptyValues', function () {
+        var options = {
+            inputVersion: '2.1.0',
+            outputVersion: '1.0.0',
+            retainIds: true,
+            retainEmptyValues: true
+        };
+
+        it('should nullify empty descriptions in when set to true', function () {
+            transformer.convert({
+                info: {
+                    _postman_id: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
+                    description: 0,
+                    schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+                },
+                item: [{
+                    _postman_id: 'f3285fa0-e361-43ba-ba15-618c7a911e84',
+                    item: [{
+                        _postman_id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                        name: '',
+                        request: {
+                            auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
+                            description: '',
+                            body: { mode: 'raw', raw: '' },
+                            header: [{ description: NaN, key: 'header_foo', value: 'header_bar' }],
+                            url: {
+                                query: [{ description: false, key: 'query_foo', value: 'query_bar' }],
+                                raw: ''
+                            }
+                        },
+                        response: []
+                    }],
+                    description: undefined
+                }]
+            }, options, function (err, result) {
+                expect(err).not.to.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    id: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
+                    description: null, // this represents the case where descriptions are removed
+                    order: [],
+                    folders_order: ['f3285fa0-e361-43ba-ba15-618c7a911e84'],
+                    folders: [{
+                        id: 'f3285fa0-e361-43ba-ba15-618c7a911e84',
+                        description: null,
+                        folders_order: [],
+                        order: ['9d123ce5-314a-40cd-9852-6a8569513f4e']
+                    }],
+                    requests: [{
+                        id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                        collectionId: '9ac7325c-cc3f-4c20-b0f8-a435766cb74c',
+                        description: null,
+                        dataMode: 'raw',
+                        name: '',
+                        pathVariableData: [],
+                        rawModeData: '',
+                        responses: [],
+                        url: '?query_foo=query_bar',
+                        data: [],
+                        headers: 'header_foo: header_bar',
+                        currentHelper: 'bearerAuth',
+                        helperAttributes: { id: 'bearer', token: 'random' },
+                        auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
+                        headerData: [{ key: 'header_foo', value: 'header_bar', description: null }],
+                        queryParams: [{ key: 'query_foo', value: 'query_bar', description: null }]
+                    }]
+                });
+            });
+        });
+
+        it('should nullify empty descriptions in requests when set to true', function () {
+            transformer.convertSingle({
+                _postman_id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                request: {
+                    auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
+                    description: null,
+                    header: [{ description: NaN, key: 'header_foo', value: 'header_bar' }],
+                    url: {
+                        query: [{ description: undefined, key: 'query_foo', value: 'query_bar' }],
+                        raw: ''
+                    }
+                },
+                response: []
+            }, options, function (err, result) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                    description: null,
+                    data: [],
+                    pathVariableData: [],
+                    responses: [],
+                    currentHelper: 'bearerAuth',
+                    helperAttributes: { id: 'bearer', token: 'random' },
+                    auth: { type: 'bearer', bearer: [{ key: 'token', value: 'random', type: 'string' }] },
+                    headers: 'header_foo: header_bar',
+                    url: '?query_foo=query_bar',
+                    rawModeData: '',
+                    headerData: [{ key: 'header_foo', value: 'header_bar', description: null }],
+                    queryParams: [{ key: 'query_foo', value: 'query_bar', description: null }]
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
This pull request standardizes empty description handling across **all** flows:

1. If `retainEmptyValues` is set to false (default), all empty descriptions will be removed, else they will be set to `null`.
2. Tests included.