### PR TITLE
Corrected formdata file value handling

### DIFF
--- a/lib/converters/v1.0.0/converter-v1-to-v2.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v2.js
@@ -200,7 +200,8 @@ _.assign(Builders.prototype, {
         }
         else if (mode === 'file') {
             data.mode = mode;
-            data[mode] = { src: _.get(requestV1, 'rawModeData') }; // @todo: Consider replicating the behaviour below
+            // @todo: Consider setting non-string src values to null, as has been done for formdata below.
+            data[mode] = { src: _.get(requestV1, 'rawModeData') };
         }
         else if (!_.isEmpty(requestV1.data)) {
             data.mode = mode;

--- a/lib/converters/v1.0.0/converter-v1-to-v2.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v2.js
@@ -205,8 +205,8 @@ _.assign(Builders.prototype, {
         else if (!_.isEmpty(requestV1.data)) {
             data.mode = mode;
             data[mode] = _.map(requestV1.data, function (param) {
-                if (param.type === 'file' && param.value) {
-                    param.src = param.value;
+                if (param.type === 'file' && _.has(param, 'value')) {
+                    param.src = _.isString(param.value) ? param.value : null;
                     delete param.value;
                 }
                 if (param.enabled === false) {

--- a/lib/converters/v1.0.0/converter-v1-to-v2.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v2.js
@@ -200,7 +200,7 @@ _.assign(Builders.prototype, {
         }
         else if (mode === 'file') {
             data.mode = mode;
-            data[mode] = { src: _.get(requestV1, 'rawModeData') };
+            data[mode] = { src: _.get(requestV1, 'rawModeData') }; // @todo: Consider replicating the behaviour below
         }
         else if (!_.isEmpty(requestV1.data)) {
             data.mode = mode;

--- a/lib/converters/v2.0.0/converter-v2-to-v1.js
+++ b/lib/converters/v2.0.0/converter-v2-to-v1.js
@@ -155,8 +155,8 @@ _.assign(Builders.prototype, {
 
         return _.map(item.request.body[mode], function (elem) {
             // Only update the value in v1 if src in v2 is non-empty
-            if (elem && elem.type === 'file' && _.has(elem, 'src') && !_.isEmpty(elem.src)) {
-                elem.value = elem.src;
+            if (elem && elem.type === 'file' && _.has(elem, 'src')) {
+                elem.value = _.isString(elem.src) ? elem.src : null;
                 delete elem.src;
             }
 

--- a/lib/normalizers/v1.js
+++ b/lib/normalizers/v1.js
@@ -148,12 +148,19 @@ _.assign(Builders.prototype, {
     data: function (requestV1) {
         if (!requestV1) { return; }
 
-        var mode = requestV1.dataMode;
+        var mode = requestV1.dataMode,
+            options = this.options || {};
 
         if ((!mode || mode === 'binary') && !this.options.noDefaults) { return []; }
         if (!requestV1.data) { return; }
 
-        _.isArray(requestV1.data) && normalizeEntities(requestV1.data, this.options);
+        _.forEach(requestV1.data, function (datum) {
+            if (datum.type === 'file' && (_.has(datum, 'value') || !options.noDefaults)) {
+                datum.value = _.isString(datum.value) ? datum.value : null;
+            }
+
+            util.cleanEmptyValue(datum, 'description', options.retainEmptyValues);
+        });
 
         return requestV1.data;
     },

--- a/lib/normalizers/v1.js
+++ b/lib/normalizers/v1.js
@@ -155,7 +155,7 @@ _.assign(Builders.prototype, {
         if ((!mode || mode === 'binary') && !noDefaults) { return []; }
         if (!requestV1.data) { return; }
 
-        _.forEach(requestV1.data, function (datum) {
+        _.isArray(requestV1.data) && _.forEach(requestV1.data, function (datum) {
             if (datum.type === 'file' && (_.has(datum, 'value') || !noDefaults)) {
                 datum.value = _.isString(datum.value) ? datum.value : null;
             }

--- a/lib/normalizers/v1.js
+++ b/lib/normalizers/v1.js
@@ -149,17 +149,18 @@ _.assign(Builders.prototype, {
         if (!requestV1) { return; }
 
         var mode = requestV1.dataMode,
-            options = this.options || {};
+            noDefaults = this.options.noDefaults,
+            retainEmptyValues = this.options.retainEmptyValues;
 
-        if ((!mode || mode === 'binary') && !this.options.noDefaults) { return []; }
+        if ((!mode || mode === 'binary') && !noDefaults) { return []; }
         if (!requestV1.data) { return; }
 
         _.forEach(requestV1.data, function (datum) {
-            if (datum.type === 'file' && (_.has(datum, 'value') || !options.noDefaults)) {
+            if (datum.type === 'file' && (_.has(datum, 'value') || !noDefaults)) {
                 datum.value = _.isString(datum.value) ? datum.value : null;
             }
 
-            util.cleanEmptyValue(datum, 'description', options.retainEmptyValues);
+            util.cleanEmptyValue(datum, 'description', retainEmptyValues);
         });
 
         return requestV1.data;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chai": "4.1.2",
     "chalk": "2.4.1",
     "eslint": "4.19.1",
-    "eslint-plugin-jsdoc": "3.7.1",
+    "eslint-plugin-jsdoc": "3.8.0",
     "eslint-plugin-lodash": "2.7.0",
     "eslint-plugin-mocha": "4.12.1",
     "eslint-plugin-security": "1.4.0",
@@ -66,11 +66,11 @@
     "watchify": "3.11.0"
   },
   "dependencies": {
-    "commander": "2.16.0",
+    "commander": "2.17.1",
     "inherits": "2.0.3",
     "intel": "1.2.0",
     "lodash": "4.17.10",
-    "semver": "5.5.0",
+    "semver": "5.5.1",
     "strip-json-comments": "2.0.1"
   }
 }

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -232,6 +232,69 @@ describe('v1.0.0 to v2.0.0', function () {
                 done();
             });
         });
+
+        it('should convert non-string values to an explicit null', function (done) {
+            transformer.convert({
+                id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                name: 'body-src-check',
+                order: [
+                    '4f65e265-dd38-0a67-71a5-d9dd50fa37a1'
+                ],
+                folders: [],
+                folders_order: [],
+                requests: [
+                    {
+                        id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        headers: '',
+                        url: 'https://postman-echo.com/post',
+                        method: 'POST',
+                        data: [
+                            {
+                                key: 'file',
+                                value: [],
+                                type: 'file'
+                            }
+                        ],
+                        dataMode: 'params',
+                        collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                    }
+                ]
+            }, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql({
+                    info: {
+                        _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                        name: 'body-src-check',
+                        schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+                    },
+                    item: [
+                        {
+                            _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                            name: '',
+                            request: {
+                                body: {
+                                    mode: 'formdata',
+                                    formdata: [{
+                                        key: 'file',
+                                        src: null,
+                                        type: 'file'
+                                    }]
+                                },
+                                header: [],
+                                method: 'POST',
+                                url: 'https://postman-echo.com/post'
+                            },
+                            response: []
+                        }
+                    ]
+                });
+                done();
+            });
+        });
     });
 
     describe('auth', function () {

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -249,11 +249,8 @@ describe('v1.0.0 to v2.0.0', function () {
                         url: 'https://postman-echo.com/post',
                         method: 'POST',
                         data: [
-                            {
-                                key: 'file',
-                                value: [],
-                                type: 'file'
-                            }
+                            { key: 'alpha', value: [], type: 'file' },
+                            { key: 'beta', value: {}, type: 'file' }
                         ],
                         dataMode: 'params',
                         collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
@@ -278,11 +275,10 @@ describe('v1.0.0 to v2.0.0', function () {
                             request: {
                                 body: {
                                     mode: 'formdata',
-                                    formdata: [{
-                                        key: 'file',
-                                        src: null,
-                                        type: 'file'
-                                    }]
+                                    formdata: [
+                                        { key: 'alpha', src: null, type: 'file' },
+                                        { key: 'beta', src: null, type: 'file' }
+                                    ]
                                 },
                                 header: [],
                                 method: 'POST',
@@ -291,6 +287,44 @@ describe('v1.0.0 to v2.0.0', function () {
                             response: []
                         }
                     ]
+                });
+                done();
+            });
+        });
+
+        it('should convert non-string values to an explicit null in requests', function (done) {
+            transformer.convertSingle({
+                id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                headers: '',
+                url: 'https://postman-echo.com/post',
+                method: 'POST',
+                data: [
+                    { key: 'alpha', value: [], type: 'file' },
+                    { key: 'beta', value: {}, type: 'file' }
+                ],
+                dataMode: 'params'
+            }, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql({
+                    _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                    name: '',
+                    request: {
+                        body: {
+                            mode: 'formdata',
+                            formdata: [
+                                { key: 'alpha', src: null, type: 'file' },
+                                { key: 'beta', src: null, type: 'file' }
+                            ]
+                        },
+                        header: [],
+                        method: 'POST',
+                        url: 'https://postman-echo.com/post'
+                    },
+                    response: []
                 });
                 done();
             });

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -329,11 +329,8 @@ describe('v1.0.0 to v2.1.0', function () {
                         url: 'https://postman-echo.com/post',
                         method: 'POST',
                         data: [
-                            {
-                                key: 'file',
-                                value: [],
-                                type: 'file'
-                            }
+                            { key: 'alpha', value: [], type: 'file' },
+                            { key: 'beta', value: {}, type: 'file' }
                         ],
                         dataMode: 'params',
                         collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
@@ -358,11 +355,10 @@ describe('v1.0.0 to v2.1.0', function () {
                             request: {
                                 body: {
                                     mode: 'formdata',
-                                    formdata: [{
-                                        key: 'file',
-                                        src: null,
-                                        type: 'file'
-                                    }]
+                                    formdata: [
+                                        { key: 'alpha', src: null, type: 'file' },
+                                        { key: 'beta', src: null, type: 'file' }
+                                    ]
                                 },
                                 header: [],
                                 method: 'POST',
@@ -376,6 +372,49 @@ describe('v1.0.0 to v2.1.0', function () {
                             response: []
                         }
                     ]
+                });
+                done();
+            });
+        });
+
+        it('should convert non-string values to an explicit null in requests', function (done) {
+            transformer.convertSingle({
+                id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                headers: '',
+                url: 'https://postman-echo.com/post',
+                method: 'POST',
+                data: [
+                    { key: 'alpha', value: [], type: 'file' },
+                    { key: 'beta', value: {}, type: 'file' }
+                ],
+                dataMode: 'params'
+            }, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql({
+                    _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                    name: '',
+                    request: {
+                        body: {
+                            mode: 'formdata',
+                            formdata: [
+                                { key: 'alpha', src: null, type: 'file' },
+                                { key: 'beta', src: null, type: 'file' }
+                            ]
+                        },
+                        header: [],
+                        method: 'POST',
+                        url: {
+                            raw: 'https://postman-echo.com/post',
+                            protocol: 'https',
+                            host: ['postman-echo', 'com'],
+                            path: ['post']
+                        }
+                    },
+                    response: []
                 });
                 done();
             });

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -312,6 +312,74 @@ describe('v1.0.0 to v2.1.0', function () {
                 done();
             });
         });
+
+        it('should convert non-string values to an explicit null', function (done) {
+            transformer.convert({
+                id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                name: 'body-src-check',
+                order: [
+                    '4f65e265-dd38-0a67-71a5-d9dd50fa37a1'
+                ],
+                folders: [],
+                folders_order: [],
+                requests: [
+                    {
+                        id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        headers: '',
+                        url: 'https://postman-echo.com/post',
+                        method: 'POST',
+                        data: [
+                            {
+                                key: 'file',
+                                value: [],
+                                type: 'file'
+                            }
+                        ],
+                        dataMode: 'params',
+                        collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                    }
+                ]
+            }, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql({
+                    info: {
+                        _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                        name: 'body-src-check',
+                        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+                    },
+                    item: [
+                        {
+                            _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                            name: '',
+                            request: {
+                                body: {
+                                    mode: 'formdata',
+                                    formdata: [{
+                                        key: 'file',
+                                        src: null,
+                                        type: 'file'
+                                    }]
+                                },
+                                header: [],
+                                method: 'POST',
+                                url: {
+                                    raw: 'https://postman-echo.com/post',
+                                    protocol: 'https',
+                                    host: ['postman-echo', 'com'],
+                                    path: ['post']
+                                }
+                            },
+                            response: []
+                        }
+                    ]
+                });
+                done();
+            });
+        });
     });
 
     describe('auth', function () {

--- a/test/unit/v1.0.0/normalize-v1.test.js
+++ b/test/unit/v1.0.0/normalize-v1.test.js
@@ -1300,11 +1300,8 @@ describe('v1.0.0 normalization', function () {
                             url: 'https://postman-echo.com/post',
                             method: 'POST',
                             data: [
-                                {
-                                    key: 'file',
-                                    value: [],
-                                    type: 'file'
-                                }
+                                { key: 'alpha', value: [], type: 'file' },
+                                { key: 'beta', value: {}, type: 'file' }
                             ],
                             dataMode: 'params',
                             collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
@@ -1327,11 +1324,8 @@ describe('v1.0.0 normalization', function () {
                                 url: 'https://postman-echo.com/post',
                                 method: 'POST',
                                 data: [
-                                    {
-                                        key: 'file',
-                                        value: null,
-                                        type: 'file'
-                                    }
+                                    { key: 'alpha', value: null, type: 'file' },
+                                    { key: 'beta', value: null, type: 'file' }
                                 ],
                                 dataMode: 'params',
                                 collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
@@ -1349,9 +1343,39 @@ describe('v1.0.0 normalization', function () {
                     url: 'https://postman-echo.com/post',
                     method: 'POST',
                     data: [
+                        { key: 'alpha', value: [], type: 'file' },
+                        { key: 'beta', value: {}, type: 'file' }
+                    ],
+                    dataMode: 'params',
+                    collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                }, options, function (err, result) {
+                    expect(err).not.to.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        headers: '',
+                        url: 'https://postman-echo.com/post',
+                        method: 'POST',
+                        data: [
+                            { key: 'alpha', value: null, type: 'file' },
+                            { key: 'beta', value: null, type: 'file' }
+                        ],
+                        dataMode: 'params',
+                        collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                    });
+                    done();
+                });
+            });
+
+            it('should set missing file values to null when missing by default (noDefaults = false)', function (done) {
+                transformer.normalizeSingle({
+                    id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                    headers: '',
+                    url: 'https://postman-echo.com/post',
+                    method: 'POST',
+                    data: [
                         {
                             key: 'file',
-                            value: [],
                             type: 'file'
                         }
                     ],
@@ -1379,7 +1403,7 @@ describe('v1.0.0 normalization', function () {
                 });
             });
 
-            it('should set missing file values to null when missing and noDefaults is false', function (done) {
+            it('should not set missing file values to null when missing and noDefaults is true', function (done) {
                 transformer.normalizeSingle({
                     id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
                     headers: '',
@@ -1393,7 +1417,7 @@ describe('v1.0.0 normalization', function () {
                     ],
                     dataMode: 'params',
                     collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
-                }, _.defaults({ noDefaults: false }, options), function (err, result) {
+                }, _.defaults({ noDefaults: true }, options), function (err, result) {
                     expect(err).not.to.be.ok;
 
                     expect(JSON.parse(JSON.stringify(result))).to.eql({
@@ -1404,7 +1428,6 @@ describe('v1.0.0 normalization', function () {
                         data: [
                             {
                                 key: 'file',
-                                value: null,
                                 type: 'file'
                             }
                         ],

--- a/test/unit/v1.0.0/normalize-v1.test.js
+++ b/test/unit/v1.0.0/normalize-v1.test.js
@@ -1282,6 +1282,103 @@ describe('v1.0.0 normalization', function () {
                 });
             });
         });
+
+        describe('request file body', function () {
+            it('should correctly handle non-string file entities', function (done) {
+                transformer.normalize({
+                    id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                    name: 'body-src-check',
+                    order: [
+                        '4f65e265-dd38-0a67-71a5-d9dd50fa37a1'
+                    ],
+                    folders: [],
+                    folders_order: [],
+                    requests: [
+                        {
+                            id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                            headers: '',
+                            url: 'https://postman-echo.com/post',
+                            method: 'POST',
+                            data: [
+                                {
+                                    key: 'file',
+                                    value: [],
+                                    type: 'file'
+                                }
+                            ],
+                            dataMode: 'params',
+                            collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                        }
+                    ]
+                }, options, function (err, result) {
+                    expect(err).not.to.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                        name: 'body-src-check',
+                        order: [
+                            '4f65e265-dd38-0a67-71a5-d9dd50fa37a1'
+                        ],
+                        folders_order: [],
+                        requests: [
+                            {
+                                id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                                headers: '',
+                                url: 'https://postman-echo.com/post',
+                                method: 'POST',
+                                data: [
+                                    {
+                                        key: 'file',
+                                        value: null,
+                                        type: 'file'
+                                    }
+                                ],
+                                dataMode: 'params',
+                                collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                            }
+                        ]
+                    });
+                    done();
+                });
+            });
+
+            it('should correctly handle non-string file entities in requests', function (done) {
+                transformer.normalizeSingle({
+                    id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                    headers: '',
+                    url: 'https://postman-echo.com/post',
+                    method: 'POST',
+                    data: [
+                        {
+                            key: 'file',
+                            value: [],
+                            type: 'file'
+                        }
+                    ],
+                    dataMode: 'params',
+                    collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                }, options, function (err, result) {
+                    expect(err).not.to.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        headers: '',
+                        url: 'https://postman-echo.com/post',
+                        method: 'POST',
+                        data: [
+                            {
+                                key: 'file',
+                                value: null,
+                                type: 'file'
+                            }
+                        ],
+                        dataMode: 'params',
+                        collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                    });
+                    done();
+                });
+            });
+        });
     });
 
     describe('mutate', function () {

--- a/test/unit/v1.0.0/normalize-v1.test.js
+++ b/test/unit/v1.0.0/normalize-v1.test.js
@@ -1378,6 +1378,79 @@ describe('v1.0.0 normalization', function () {
                     done();
                 });
             });
+
+            it('should set missing file values to null when missing and noDefaults is false', function (done) {
+                transformer.normalizeSingle({
+                    id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                    headers: '',
+                    url: 'https://postman-echo.com/post',
+                    method: 'POST',
+                    data: [
+                        {
+                            key: 'file',
+                            type: 'file'
+                        }
+                    ],
+                    dataMode: 'params',
+                    collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                }, _.defaults({ noDefaults: false }, options), function (err, result) {
+                    expect(err).not.to.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        headers: '',
+                        url: 'https://postman-echo.com/post',
+                        method: 'POST',
+                        data: [
+                            {
+                                key: 'file',
+                                value: null,
+                                type: 'file'
+                            }
+                        ],
+                        dataMode: 'params',
+                        collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                    });
+                    done();
+                });
+            });
+
+            it('should retain string valued file entities in request bodies', function (done) {
+                transformer.normalizeSingle({
+                    id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                    headers: '',
+                    url: 'https://postman-echo.com/post',
+                    method: 'POST',
+                    data: [
+                        {
+                            key: 'file',
+                            value: 't.csv',
+                            type: 'file'
+                        }
+                    ],
+                    dataMode: 'params',
+                    collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                }, _.defaults({ noDefaults: false }, options), function (err, result) {
+                    expect(err).not.to.be.ok;
+
+                    expect(JSON.parse(JSON.stringify(result))).to.eql({
+                        id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        headers: '',
+                        url: 'https://postman-echo.com/post',
+                        method: 'POST',
+                        data: [
+                            {
+                                key: 'file',
+                                value: 't.csv',
+                                type: 'file'
+                            }
+                        ],
+                        dataMode: 'params',
+                        collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                    });
+                    done();
+                });
+            });
         });
     });
 

--- a/test/unit/v2.0.0/converter-v2-to-v1.test.js
+++ b/test/unit/v2.0.0/converter-v2-to-v1.test.js
@@ -408,11 +408,8 @@ describe('v2.0.0 to v1.0.0', function () {
                             body: {
                                 mode: 'formdata',
                                 formdata: [
-                                    {
-                                        key: 'file',
-                                        type: 'file',
-                                        src: []
-                                    }
+                                    { key: 'alpha', src: [], type: 'file' },
+                                    { key: 'beta', src: {}, type: 'file' }
                                 ]
                             }
                         }
@@ -436,11 +433,10 @@ describe('v2.0.0 to v1.0.0', function () {
                         url: 'https://postman-echo.com/post',
                         method: 'POST',
                         dataMode: 'params',
-                        data: [{
-                            key: 'file',
-                            type: 'file',
-                            value: null
-                        }],
+                        data: [
+                            { key: 'alpha', value: null, type: 'file' },
+                            { key: 'beta', value: null, type: 'file' }
+                        ],
                         headers: '',
                         headerData: [],
                         queryParams: [],
@@ -461,11 +457,8 @@ describe('v2.0.0 to v1.0.0', function () {
                     body: {
                         mode: 'formdata',
                         formdata: [
-                            {
-                                key: 'file',
-                                type: 'file',
-                                src: []
-                            }
+                            { key: 'alpha', type: 'file', src: [] },
+                            { key: 'beta', type: 'file', src: {} }
                         ]
                     }
                 }
@@ -480,11 +473,10 @@ describe('v2.0.0 to v1.0.0', function () {
                     url: 'https://postman-echo.com/post',
                     method: 'POST',
                     dataMode: 'params',
-                    data: [{
-                        key: 'file',
-                        type: 'file',
-                        value: null
-                    }],
+                    data: [
+                        { key: 'alpha', type: 'file', value: null },
+                        { key: 'beta', type: 'file', value: null }
+                    ],
                     headers: '',
                     headerData: [],
                     queryParams: [],

--- a/test/unit/v2.0.0/converter-v2-to-v1.test.js
+++ b/test/unit/v2.0.0/converter-v2-to-v1.test.js
@@ -391,6 +391,109 @@ describe('v2.0.0 to v1.0.0', function () {
                 done();
             });
         });
+
+        it('should correctly handle non-string bodies whilst converting from v2 to v1', function (done) {
+            transformer.convert({
+                info: {
+                    name: 'body-src-check',
+                    _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                    schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+                },
+                item: [
+                    {
+                        _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        request: {
+                            url: 'https://postman-echo.com/post',
+                            method: 'POST',
+                            body: {
+                                mode: 'formdata',
+                                formdata: [
+                                    {
+                                        key: 'file',
+                                        type: 'file',
+                                        src: []
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql({
+                    id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                    name: 'body-src-check',
+                    order: ['4f65e265-dd38-0a67-71a5-d9dd50fa37a1'],
+                    folders: [],
+                    folders_order: [],
+                    requests: [{
+                        id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                        url: 'https://postman-echo.com/post',
+                        method: 'POST',
+                        dataMode: 'params',
+                        data: [{
+                            key: 'file',
+                            type: 'file',
+                            value: null
+                        }],
+                        headers: '',
+                        headerData: [],
+                        queryParams: [],
+                        pathVariableData: [],
+                        rawModeData: ''
+                    }]
+                });
+                done();
+            });
+        });
+
+        it('should correctly handle non-string bodies whilst converting requests from v2 to v1', function (done) {
+            transformer.convertSingle({
+                _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                request: {
+                    url: 'https://postman-echo.com/post',
+                    method: 'POST',
+                    body: {
+                        mode: 'formdata',
+                        formdata: [
+                            {
+                                key: 'file',
+                                type: 'file',
+                                src: []
+                            }
+                        ]
+                    }
+                }
+            }, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql({
+                    id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                    url: 'https://postman-echo.com/post',
+                    method: 'POST',
+                    dataMode: 'params',
+                    data: [{
+                        key: 'file',
+                        type: 'file',
+                        value: null
+                    }],
+                    headers: '',
+                    headerData: [],
+                    queryParams: [],
+                    pathVariableData: [],
+                    rawModeData: ''
+                });
+                done();
+            });
+        });
     });
 
     describe('auth', function () {

--- a/test/unit/v2.1.0/converter-v21-to-v1.test.js
+++ b/test/unit/v2.1.0/converter-v21-to-v1.test.js
@@ -291,6 +291,119 @@ describe('v2.1.0 to v1.0.0', function () {
                 done();
             });
         });
+
+        it('should correctly handle non-string bodies whilst converting from v2 to v1', function (done) {
+            transformer.convert({
+                info: {
+                    name: 'body-src-check',
+                    _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                    schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+                },
+                item: [
+                    {
+                        _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        request: {
+                            url: {
+                                raw: 'https://postman-echo.com/post',
+                                protocol: 'https',
+                                host: ['postman-echo', 'com'],
+                                path: ['post']
+                            },
+                            method: 'POST',
+                            body: {
+                                mode: 'formdata',
+                                formdata: [
+                                    {
+                                        key: 'file',
+                                        type: 'file',
+                                        src: []
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql({
+                    id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                    name: 'body-src-check',
+                    order: ['4f65e265-dd38-0a67-71a5-d9dd50fa37a1'],
+                    folders: [],
+                    folders_order: [],
+                    requests: [{
+                        id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                        url: 'https://postman-echo.com/post',
+                        method: 'POST',
+                        dataMode: 'params',
+                        data: [{
+                            key: 'file',
+                            type: 'file',
+                            value: null
+                        }],
+                        headers: '',
+                        headerData: [],
+                        queryParams: [],
+                        pathVariableData: [],
+                        rawModeData: ''
+                    }]
+                });
+                done();
+            });
+        });
+
+        it('should correctly handle non-string bodies whilst converting requests from v2 to v1', function (done) {
+            transformer.convertSingle({
+                _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                request: {
+                    url: {
+                        raw: 'https://postman-echo.com/post',
+                        protocol: 'https',
+                        host: ['postman-echo', 'com'],
+                        path: ['post']
+                    },
+                    method: 'POST',
+                    body: {
+                        mode: 'formdata',
+                        formdata: [
+                            {
+                                key: 'file',
+                                type: 'file',
+                                src: []
+                            }
+                        ]
+                    }
+                }
+            }, options, function (err, converted) {
+                expect(err).to.not.be.ok;
+
+                // remove `undefined` properties for testing
+                converted = JSON.parse(JSON.stringify(converted));
+
+                expect(converted).to.eql({
+                    id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                    url: 'https://postman-echo.com/post',
+                    method: 'POST',
+                    dataMode: 'params',
+                    data: [{
+                        key: 'file',
+                        type: 'file',
+                        value: null
+                    }],
+                    headers: '',
+                    headerData: [],
+                    queryParams: [],
+                    pathVariableData: [],
+                    rawModeData: ''
+                });
+                done();
+            });
+        });
     });
 
     describe('auth', function () {

--- a/test/unit/v2.1.0/converter-v21-to-v1.test.js
+++ b/test/unit/v2.1.0/converter-v21-to-v1.test.js
@@ -313,11 +313,8 @@ describe('v2.1.0 to v1.0.0', function () {
                             body: {
                                 mode: 'formdata',
                                 formdata: [
-                                    {
-                                        key: 'file',
-                                        type: 'file',
-                                        src: []
-                                    }
+                                    { key: 'alpha', src: [], type: 'file' },
+                                    { key: 'beta', src: {}, type: 'file' }
                                 ]
                             }
                         }
@@ -341,11 +338,10 @@ describe('v2.1.0 to v1.0.0', function () {
                         url: 'https://postman-echo.com/post',
                         method: 'POST',
                         dataMode: 'params',
-                        data: [{
-                            key: 'file',
-                            type: 'file',
-                            value: null
-                        }],
+                        data: [
+                            { key: 'alpha', value: null, type: 'file' },
+                            { key: 'beta', value: null, type: 'file' }
+                        ],
                         headers: '',
                         headerData: [],
                         queryParams: [],
@@ -371,11 +367,8 @@ describe('v2.1.0 to v1.0.0', function () {
                     body: {
                         mode: 'formdata',
                         formdata: [
-                            {
-                                key: 'file',
-                                type: 'file',
-                                src: []
-                            }
+                            { key: 'alpha', type: 'file', src: [] },
+                            { key: 'beta', type: 'file', src: {} }
                         ]
                     }
                 }
@@ -390,11 +383,10 @@ describe('v2.1.0 to v1.0.0', function () {
                     url: 'https://postman-echo.com/post',
                     method: 'POST',
                     dataMode: 'params',
-                    data: [{
-                        key: 'file',
-                        type: 'file',
-                        value: null
-                    }],
+                    data: [
+                        { key: 'alpha', type: 'file', value: null },
+                        { key: 'beta', type: 'file', value: null }
+                    ],
                     headers: '',
                     headerData: [],
                     queryParams: [],


### PR DESCRIPTION
In cases where the file src(v2.x) or value(v1) was a non-string value, it would be passed on as is. This resulted in certain collections becoming malformed and unusable from the perspective of the Postman API. (Attempts to POST/PUT such collections would result in confusing schema validation errors).

This pull request ensures that non-string file entities are correctly set to `null`.

Tests included.