### PR TITLE
Convert `protocolProfileBehavior` at collection and folder level

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -2,6 +2,10 @@ master:
   new features:
     - >-
       GH-235 Added support for request body options.
+    - >-
+      GH-236 Added support for converting `protocolProfileBehavior` at folder
+      and collection level.
+
 3.1.2:
   date: 2019-08-01
   chores:

--- a/lib/converters/v1.0.0/converter-v1-to-v2.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v2.js
@@ -399,26 +399,6 @@ _.assign(Builders.prototype, {
     },
 
     /**
-     * Contructs a v2 protocol profile behavior object from v1 entity.
-     *
-     * @param {Object} entityV1 - The v1 entity to derive protocol behavior from.
-     * @returns {ProtocolProfileBehavior} - The protocol behavior configuration.
-    */
-    protocolProfileBehavior: function (entityV1) {
-        if (!entityV1) {
-            return;
-        }
-
-        let result = {};
-
-        if (!util.addProtocolProfileBehavior(entityV1, result)) {
-            return;
-        }
-
-        return result.protocolProfileBehavior;
-    },
-
-    /**
      * A number of auth parameter names have changed from V1 to V2. This function calls the appropriate
      * mapper function, and creates the V2 auth parameter object.
      *
@@ -665,7 +645,6 @@ _.assign(Builders.prototype, {
             var auth = self.auth(folder),
                 event = self.event(folder),
                 variable = self.variable(folder),
-                protocolProfileBehavior = self.protocolProfileBehavior(folder),
                 result = {
                     name: folder.name,
                     item: []
@@ -679,7 +658,7 @@ _.assign(Builders.prototype, {
             (auth || (auth === null)) && (result.auth = auth);
             event && (result.event = event);
             variable && variable.length && (result.variable = variable);
-            protocolProfileBehavior && (result.protocolProfileBehavior = protocolProfileBehavior);
+            util.addProtocolProfileBehavior(folder, result);
 
             accumulator[folder.id] = result;
 
@@ -837,7 +816,6 @@ module.exports = {
         var auth,
             event,
             variable,
-            protocolProfileBehavior,
             newCollection = {},
             units = ['info', 'item'],
             builders = new Builders(options),
@@ -852,8 +830,7 @@ module.exports = {
             (auth = builders.auth(collection, authOptions)) && (newCollection.auth = auth);
             (event = builders.event(collection)) && (newCollection.event = event);
             (variable = builders.variable(collection, varOpts)) && (newCollection.variable = variable);
-            (protocolProfileBehavior = builders.protocolProfileBehavior(collection)) &&
-                (newCollection.protocolProfileBehavior = protocolProfileBehavior);
+            util.addProtocolProfileBehavior(collection, newCollection);
         }
         catch (e) {
             if (callback) {

--- a/lib/converters/v1.0.0/converter-v1-to-v2.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v2.js
@@ -399,6 +399,26 @@ _.assign(Builders.prototype, {
     },
 
     /**
+     * Contructs a v2 protocol profile behavior object from v1 entity.
+     *
+     * @param {Object} entityV1 - The v1 entity to derive protocol behavior from.
+     * @returns {ProtocolProfileBehavior} - The protocol behavior configuration.
+    */
+    protocolProfileBehavior: function (entityV1) {
+        if (!entityV1) {
+            return;
+        }
+
+        let result = {};
+
+        if (!util.addProtocolProfileBehavior(entityV1, result)) {
+            return;
+        }
+
+        return result.protocolProfileBehavior;
+    },
+
+    /**
      * A number of auth parameter names have changed from V1 to V2. This function calls the appropriate
      * mapper function, and creates the V2 auth parameter object.
      *
@@ -645,6 +665,7 @@ _.assign(Builders.prototype, {
             var auth = self.auth(folder),
                 event = self.event(folder),
                 variable = self.variable(folder),
+                protocolProfileBehavior = self.protocolProfileBehavior(folder),
                 result = {
                     name: folder.name,
                     item: []
@@ -658,6 +679,7 @@ _.assign(Builders.prototype, {
             (auth || (auth === null)) && (result.auth = auth);
             event && (result.event = event);
             variable && variable.length && (result.variable = variable);
+            protocolProfileBehavior && (result.protocolProfileBehavior = protocolProfileBehavior);
 
             accumulator[folder.id] = result;
 
@@ -815,6 +837,7 @@ module.exports = {
         var auth,
             event,
             variable,
+            protocolProfileBehavior,
             newCollection = {},
             units = ['info', 'item'],
             builders = new Builders(options),
@@ -829,6 +852,8 @@ module.exports = {
             (auth = builders.auth(collection, authOptions)) && (newCollection.auth = auth);
             (event = builders.event(collection)) && (newCollection.event = event);
             (variable = builders.variable(collection, varOpts)) && (newCollection.variable = variable);
+            (protocolProfileBehavior = builders.protocolProfileBehavior(collection)) &&
+                (newCollection.protocolProfileBehavior = protocolProfileBehavior);
         }
         catch (e) {
             if (callback) {

--- a/lib/converters/v1.0.0/converter-v1-to-v21.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v21.js
@@ -129,6 +129,7 @@ module.exports = {
         var auth,
             event,
             variable,
+            protocolProfileBehavior,
             newCollection = {},
             units = ['info', 'item'],
             builders = new Builders(options),
@@ -143,6 +144,8 @@ module.exports = {
             (auth = builders.auth(collection, authOptions)) && (newCollection.auth = auth);
             (event = builders.event(collection)) && (newCollection.event = event);
             (variable = builders.variable(collection, varOpts)) && (newCollection.variable = variable);
+            (protocolProfileBehavior = builders.protocolProfileBehavior(collection)) &&
+                (newCollection.protocolProfileBehavior = protocolProfileBehavior);
         }
         catch (e) {
             if (callback) { return callback(e); }

--- a/lib/converters/v1.0.0/converter-v1-to-v21.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v21.js
@@ -129,7 +129,6 @@ module.exports = {
         var auth,
             event,
             variable,
-            protocolProfileBehavior,
             newCollection = {},
             units = ['info', 'item'],
             builders = new Builders(options),
@@ -144,8 +143,7 @@ module.exports = {
             (auth = builders.auth(collection, authOptions)) && (newCollection.auth = auth);
             (event = builders.event(collection)) && (newCollection.event = event);
             (variable = builders.variable(collection, varOpts)) && (newCollection.variable = variable);
-            (protocolProfileBehavior = builders.protocolProfileBehavior(collection)) &&
-                (newCollection.protocolProfileBehavior = protocolProfileBehavior);
+            util.addProtocolProfileBehavior(collection, newCollection);
         }
         catch (e) {
             if (callback) { return callback(e); }

--- a/lib/converters/v2.0.0/converter-v2-to-v1.js
+++ b/lib/converters/v2.0.0/converter-v2-to-v1.js
@@ -24,26 +24,6 @@ _.assign(Builders.prototype, {
     },
 
     /**
-     * Contructs a v1 protocol profile behavior object from v2 entity.
-     *
-     * @param {Object} entityV2 - The v2 entity to derive protocol behavior from.
-     * @returns {ProtocolProfileBehavior} - The protocol behavior configuration.
-    */
-    protocolProfileBehavior: function (entityV2) {
-        if (!entityV2) {
-            return;
-        }
-
-        let result = {};
-
-        if (!util.addProtocolProfileBehavior(entityV2, result)) {
-            return;
-        }
-
-        return result.protocolProfileBehavior;
-    },
-
-    /**
      * Constructs a V1 "events" object from a V2 Postman entity
      *
      * @param {Object} entityV2 - The v2 event object to be converted.
@@ -622,7 +602,6 @@ _.assign(Builders.prototype, {
                 auth = self.auth(folder),
                 events = self.events(folder),
                 variables = self.variables(folder),
-                protocolProfileBehavior = self.protocolProfileBehavior(folder),
 
                 result = {
 
@@ -645,7 +624,7 @@ _.assign(Builders.prototype, {
             ((auth && auth.type) || (auth === null)) && (result.auth = auth);
             events && events.length && (result.events = events);
             variables && variables.length && (result.variables = variables);
-            protocolProfileBehavior && (result.protocolProfileBehavior = protocolProfileBehavior);
+            util.addProtocolProfileBehavior(folder, result);
 
             // Prevent empty folder descriptions from showing up in the result, keeps collections clean.
             if (description) { result.description = description; }
@@ -751,7 +730,6 @@ module.exports = {
         var auth,
             events,
             variables,
-            protocolProfileBehavior,
             builders = new Builders(options),
             authOptions = { excludeNoauth: true },
             varOpts = { fallback: options && options.env },
@@ -771,8 +749,7 @@ module.exports = {
             (auth = builders.auth(collection, authOptions)) && (newCollection.auth = auth);
             (events = builders.events(collection)) && (newCollection.events = events);
             (variables = builders.variables(collection, varOpts)) && (newCollection.variables = variables);
-            (protocolProfileBehavior = builders.protocolProfileBehavior(collection)) &&
-                (newCollection.protocolProfileBehavior = protocolProfileBehavior);
+            util.addProtocolProfileBehavior(collection, newCollection);
 
             units.forEach(function (unit) {
                 newCollection[unit] = builders[unit](collection);

--- a/lib/converters/v2.0.0/converter-v2-to-v1.js
+++ b/lib/converters/v2.0.0/converter-v2-to-v1.js
@@ -24,6 +24,26 @@ _.assign(Builders.prototype, {
     },
 
     /**
+     * Contructs a v1 protocol profile behavior object from v2 entity.
+     *
+     * @param {Object} entityV2 - The v2 entity to derive protocol behavior from.
+     * @returns {ProtocolProfileBehavior} - The protocol behavior configuration.
+    */
+    protocolProfileBehavior: function (entityV2) {
+        if (!entityV2) {
+            return;
+        }
+
+        let result = {};
+
+        if (!util.addProtocolProfileBehavior(entityV2, result)) {
+            return;
+        }
+
+        return result.protocolProfileBehavior;
+    },
+
+    /**
      * Constructs a V1 "events" object from a V2 Postman entity
      *
      * @param {Object} entityV2 - The v2 event object to be converted.
@@ -602,6 +622,7 @@ _.assign(Builders.prototype, {
                 auth = self.auth(folder),
                 events = self.events(folder),
                 variables = self.variables(folder),
+                protocolProfileBehavior = self.protocolProfileBehavior(folder),
 
                 result = {
 
@@ -624,6 +645,7 @@ _.assign(Builders.prototype, {
             ((auth && auth.type) || (auth === null)) && (result.auth = auth);
             events && events.length && (result.events = events);
             variables && variables.length && (result.variables = variables);
+            protocolProfileBehavior && (result.protocolProfileBehavior = protocolProfileBehavior);
 
             // Prevent empty folder descriptions from showing up in the result, keeps collections clean.
             if (description) { result.description = description; }
@@ -729,6 +751,7 @@ module.exports = {
         var auth,
             events,
             variables,
+            protocolProfileBehavior,
             builders = new Builders(options),
             authOptions = { excludeNoauth: true },
             varOpts = { fallback: options && options.env },
@@ -748,6 +771,8 @@ module.exports = {
             (auth = builders.auth(collection, authOptions)) && (newCollection.auth = auth);
             (events = builders.events(collection)) && (newCollection.events = events);
             (variables = builders.variables(collection, varOpts)) && (newCollection.variables = variables);
+            (protocolProfileBehavior = builders.protocolProfileBehavior(collection)) &&
+                (newCollection.protocolProfileBehavior = protocolProfileBehavior);
 
             units.forEach(function (unit) {
                 newCollection[unit] = builders[unit](collection);

--- a/lib/converters/v2.1.0/converter-v21-to-v1.js
+++ b/lib/converters/v2.1.0/converter-v21-to-v1.js
@@ -88,6 +88,7 @@ module.exports = {
         var auth,
             events,
             variables,
+            protocolProfileBehavior,
             builders = new Builders(options),
             authOptions = { excludeNoauth: true },
             units = ['order', 'folders_order', 'folders', 'requests'],
@@ -107,6 +108,8 @@ module.exports = {
             (auth = builders.auth(collection, authOptions)) && (newCollection.auth = auth);
             (events = builders.events(collection)) && (newCollection.events = events);
             (variables = builders.variables(collection, varOpts)) && (newCollection.variables = variables);
+            (protocolProfileBehavior = builders.protocolProfileBehavior(collection)) &&
+                (newCollection.protocolProfileBehavior = protocolProfileBehavior);
 
             units.forEach(function (unit) {
                 newCollection[unit] = builders[unit](collection);

--- a/lib/converters/v2.1.0/converter-v21-to-v1.js
+++ b/lib/converters/v2.1.0/converter-v21-to-v1.js
@@ -88,7 +88,6 @@ module.exports = {
         var auth,
             events,
             variables,
-            protocolProfileBehavior,
             builders = new Builders(options),
             authOptions = { excludeNoauth: true },
             units = ['order', 'folders_order', 'folders', 'requests'],
@@ -108,8 +107,7 @@ module.exports = {
             (auth = builders.auth(collection, authOptions)) && (newCollection.auth = auth);
             (events = builders.events(collection)) && (newCollection.events = events);
             (variables = builders.variables(collection, varOpts)) && (newCollection.variables = variables);
-            (protocolProfileBehavior = builders.protocolProfileBehavior(collection)) &&
-                (newCollection.protocolProfileBehavior = protocolProfileBehavior);
+            util.addProtocolProfileBehavior(collection, newCollection);
 
             units.forEach(function (unit) {
                 newCollection[unit] = builders[unit](collection);

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -1577,7 +1577,7 @@ describe('v1.0.0 to v2.0.0', function () {
 
     describe('protocolProfileBehavior', function () {
         describe('with convert', function () {
-            it('should be handled correctly', function (done) {
+            it('should be converted at request level', function (done) {
                 transformer.convert({
                     id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
                     name: 'get-with-body',
@@ -1621,6 +1621,122 @@ describe('v1.0.0 to v2.0.0', function () {
                                 url: 'https://postman-echo.com/get'
                             },
                             response: [],
+                            protocolProfileBehavior: {
+                                disableBodyPruning: true
+                            }
+                        }]
+                    });
+                    done();
+                });
+            });
+
+            it('should be converted at collection level', function (done) {
+                transformer.convert({
+                    id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                    name: 'get-with-body',
+                    order: ['4f65e265-dd38-0a67-71a5-d9dd50fa37a1'],
+                    folders: [],
+                    folders_order: [],
+                    requests: [{
+                        id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        headers: '',
+                        url: 'https://postman-echo.com/get',
+                        data: 'foo=bar',
+                        method: 'GET',
+                        dataMode: 'raw',
+                        collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                    }],
+                    protocolProfileBehavior: {
+                        disableBodyPruning: true
+                    }
+                }, options, function (err, converted) {
+                    expect(err).to.not.be.ok;
+
+                    // remove `undefined` properties for testing
+                    converted = JSON.parse(JSON.stringify(converted));
+
+                    expect(converted).to.eql({
+                        info: {
+                            _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                            name: 'get-with-body',
+                            schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+                        },
+                        item: [{
+                            _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                            name: '',
+                            request: {
+                                body: {
+                                    mode: 'raw',
+                                    raw: 'foo=bar'
+                                },
+                                header: [],
+                                method: 'GET',
+                                url: 'https://postman-echo.com/get'
+                            },
+                            response: []
+                        }],
+                        protocolProfileBehavior: {
+                            disableBodyPruning: true
+                        }
+                    });
+                    done();
+                });
+            });
+
+            it('should be converted at folder level', function (done) {
+                transformer.convert({
+                    id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                    name: 'get-with-body',
+                    order: [],
+                    folders: [{
+                        id: '5f321b3e-bfdd-4018-80d0-789351444674',
+                        order: [
+                            '4f65e265-dd38-0a67-71a5-d9dd50fa37a1'
+                        ],
+                        protocolProfileBehavior: {
+                            disableBodyPruning: true
+                        }
+                    }],
+                    folders_order: [
+                        '5f321b3e-bfdd-4018-80d0-789351444674'
+                    ],
+                    requests: [{
+                        id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        headers: '',
+                        url: 'https://postman-echo.com/get',
+                        data: 'foo=bar',
+                        method: 'GET',
+                        dataMode: 'raw',
+                        collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                    }]
+                }, options, function (err, converted) {
+                    expect(err).to.not.be.ok;
+
+                    // remove `undefined` properties for testing
+                    converted = JSON.parse(JSON.stringify(converted));
+
+                    expect(converted).to.eql({
+                        info: {
+                            _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                            name: 'get-with-body',
+                            schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+                        },
+                        item: [{
+                            _postman_id: '5f321b3e-bfdd-4018-80d0-789351444674',
+                            item: [{
+                                _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                                name: '',
+                                request: {
+                                    body: {
+                                        mode: 'raw',
+                                        raw: 'foo=bar'
+                                    },
+                                    header: [],
+                                    method: 'GET',
+                                    url: 'https://postman-echo.com/get'
+                                },
+                                response: []
+                            }],
                             protocolProfileBehavior: {
                                 disableBodyPruning: true
                             }

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -1504,7 +1504,7 @@ describe('v1.0.0 to v2.1.0', function () {
 
     describe('protocolProfileBehavior', function () {
         describe('with convert', function () {
-            it('should be handled correctly', function (done) {
+            it('should be converted at request level', function (done) {
                 transformer.convert({
                     id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
                     name: 'get-with-body',
@@ -1553,6 +1553,132 @@ describe('v1.0.0 to v2.1.0', function () {
                                 }
                             },
                             response: [],
+                            protocolProfileBehavior: {
+                                disableBodyPruning: true
+                            }
+                        }]
+                    });
+                    done();
+                });
+            });
+
+            it('should be converted at collection level', function (done) {
+                transformer.convert({
+                    id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                    name: 'get-with-body',
+                    order: ['4f65e265-dd38-0a67-71a5-d9dd50fa37a1'],
+                    folders: [],
+                    folders_order: [],
+                    requests: [{
+                        id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        headers: '',
+                        url: 'https://postman-echo.com/get',
+                        data: 'foo=bar',
+                        method: 'GET',
+                        dataMode: 'raw',
+                        collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                    }],
+                    protocolProfileBehavior: {
+                        disableBodyPruning: true
+                    }
+                }, options, function (err, converted) {
+                    expect(err).to.not.be.ok;
+
+                    // remove `undefined` properties for testing
+                    converted = JSON.parse(JSON.stringify(converted));
+
+                    expect(converted).to.eql({
+                        info: {
+                            _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                            name: 'get-with-body',
+                            schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+                        },
+                        item: [{
+                            _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                            name: '',
+                            request: {
+                                body: {
+                                    mode: 'raw',
+                                    raw: 'foo=bar'
+                                },
+                                header: [],
+                                method: 'GET',
+                                url: {
+                                    host: ['postman-echo', 'com'],
+                                    path: ['get'],
+                                    protocol: 'https',
+                                    raw: 'https://postman-echo.com/get'
+                                }
+                            },
+                            response: []
+                        }],
+                        protocolProfileBehavior: {
+                            disableBodyPruning: true
+                        }
+                    });
+                    done();
+                });
+            });
+
+            it('should be converted at folder level', function (done) {
+                transformer.convert({
+                    id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                    name: 'get-with-body',
+                    order: [],
+                    folders: [{
+                        id: '5f321b3e-bfdd-4018-80d0-789351444674',
+                        order: [
+                            '4f65e265-dd38-0a67-71a5-d9dd50fa37a1'
+                        ],
+                        protocolProfileBehavior: {
+                            disableBodyPruning: true
+                        }
+                    }],
+                    folders_order: [
+                        '5f321b3e-bfdd-4018-80d0-789351444674'
+                    ],
+                    requests: [{
+                        id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        headers: '',
+                        url: 'https://postman-echo.com/get',
+                        data: 'foo=bar',
+                        method: 'GET',
+                        dataMode: 'raw',
+                        collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2'
+                    }]
+                }, options, function (err, converted) {
+                    expect(err).to.not.be.ok;
+
+                    // remove `undefined` properties for testing
+                    converted = JSON.parse(JSON.stringify(converted));
+
+                    expect(converted).to.eql({
+                        info: {
+                            _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                            name: 'get-with-body',
+                            schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+                        },
+                        item: [{
+                            _postman_id: '5f321b3e-bfdd-4018-80d0-789351444674',
+                            item: [{
+                                _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                                name: '',
+                                request: {
+                                    body: {
+                                        mode: 'raw',
+                                        raw: 'foo=bar'
+                                    },
+                                    header: [],
+                                    method: 'GET',
+                                    url: {
+                                        host: ['postman-echo', 'com'],
+                                        path: ['get'],
+                                        protocol: 'https',
+                                        raw: 'https://postman-echo.com/get'
+                                    }
+                                },
+                                response: []
+                            }],
                             protocolProfileBehavior: {
                                 disableBodyPruning: true
                             }

--- a/test/unit/v2.0.0/converter-v2-to-v1.test.js
+++ b/test/unit/v2.0.0/converter-v2-to-v1.test.js
@@ -1240,7 +1240,7 @@ describe('v2.0.0 to v1.0.0', function () {
 
     describe('protocolProfileBehavior', function () {
         describe('with convert', function () {
-            it('should be handled correctly', function (done) {
+            it('should be converted at request level', function (done) {
                 transformer.convert({
                     info: {
                         _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
@@ -1286,6 +1286,131 @@ describe('v2.0.0 to v1.0.0', function () {
                             protocolProfileBehavior: {
                                 disableBodyPruning: true
                             },
+                            rawModeData: 'foo=bar',
+                            url: 'https://postman-echo.com/get',
+                            responses: [],
+                            pathVariableData: [],
+                            queryParams: [],
+                            headerData: []
+                        }]
+                    });
+                    done();
+                });
+            });
+
+            it('should be converted at collection level', function (done) {
+                transformer.convert({
+                    info: {
+                        _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                        name: 'get-with-body',
+                        schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+                    },
+                    item: [{
+                        _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        name: '',
+                        request: {
+                            body: {
+                                mode: 'raw',
+                                raw: 'foo=bar'
+                            },
+                            header: [],
+                            method: 'GET',
+                            url: 'https://postman-echo.com/get'
+                        },
+                        response: []
+                    }],
+                    protocolProfileBehavior: {
+                        disableBodyPruning: true
+                    }
+                }, options, function (err, converted) {
+                    expect(err).to.not.be.ok;
+
+                    // remove `undefined` properties for testing
+                    converted = JSON.parse(JSON.stringify(converted));
+
+                    expect(converted).to.eql({
+                        id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                        name: 'get-with-body',
+                        order: ['4f65e265-dd38-0a67-71a5-d9dd50fa37a1'],
+                        folders_order: [],
+                        folders: [],
+                        requests: [{
+                            id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                            name: '',
+                            collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                            method: 'GET',
+                            headers: '',
+                            dataMode: 'raw',
+                            rawModeData: 'foo=bar',
+                            url: 'https://postman-echo.com/get',
+                            responses: [],
+                            pathVariableData: [],
+                            queryParams: [],
+                            headerData: []
+                        }],
+                        protocolProfileBehavior: {
+                            disableBodyPruning: true
+                        }
+                    });
+                    done();
+                });
+            });
+
+            it('should be converted at folder level', function (done) {
+                transformer.convert({
+                    info: {
+                        _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                        name: 'collection',
+                        schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+                    },
+                    item: [{
+                        name: 'folder',
+                        _postman_id: 'ed6e0a03-f4c3-429b-9df3-6dc332f17e78',
+                        item: [{
+                            name: '',
+                            _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                            request: {
+                                body: {
+                                    mode: 'raw',
+                                    raw: 'foo=bar'
+                                },
+                                header: [],
+                                method: 'GET',
+                                url: 'https://postman-echo.com/get'
+                            },
+                            response: []
+                        }],
+                        protocolProfileBehavior: {
+                            disableBodyPruning: true
+                        }
+                    }]
+                }, options, function (err, converted) {
+                    expect(err).to.not.be.ok;
+
+                    // remove `undefined` properties for testing
+                    converted = JSON.parse(JSON.stringify(converted));
+
+                    expect(converted).to.eql({
+                        id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                        name: 'collection',
+                        folders_order: ['ed6e0a03-f4c3-429b-9df3-6dc332f17e78'],
+                        folders: [{
+                            folders_order: [],
+                            id: 'ed6e0a03-f4c3-429b-9df3-6dc332f17e78',
+                            name: 'folder',
+                            order: ['4f65e265-dd38-0a67-71a5-d9dd50fa37a1'],
+                            protocolProfileBehavior: {
+                                disableBodyPruning: true
+                            }
+                        }],
+                        order: [],
+                        requests: [{
+                            id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                            name: '',
+                            collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                            method: 'GET',
+                            headers: '',
+                            dataMode: 'raw',
                             rawModeData: 'foo=bar',
                             url: 'https://postman-echo.com/get',
                             responses: [],

--- a/test/unit/v2.1.0/converter-v21-to-v1.test.js
+++ b/test/unit/v2.1.0/converter-v21-to-v1.test.js
@@ -1192,7 +1192,7 @@ describe('v2.1.0 to v1.0.0', function () {
 
     describe('protocolProfileBehavior', function () {
         describe('with convert', function () {
-            it('should be handled correctly', function (done) {
+            it('should be converted at request level', function (done) {
                 transformer.convert({
                     info: {
                         _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
@@ -1250,6 +1250,108 @@ describe('v2.1.0 to v1.0.0', function () {
                             queryParams: [],
                             headerData: []
                         }]
+                    });
+                    done();
+                });
+            });
+
+            it('should be converted at collection level', function (done) {
+                transformer.convert({
+                    info: {
+                        _postman_id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                        name: 'get-with-body',
+                        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+                    },
+                    item: [{
+                        _postman_id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                        name: '',
+                        request: {
+                            body: {
+                                mode: 'raw',
+                                raw: 'foo=bar'
+                            },
+                            header: [],
+                            method: 'GET',
+                            url: {
+                                host: ['postman-echo', 'com'],
+                                path: ['get'],
+                                protocol: 'https',
+                                raw: 'https://postman-echo.com/get'
+                            }
+                        },
+                        response: []
+                    }],
+                    protocolProfileBehavior: {
+                        disableBodyPruning: true
+                    }
+                }, options, function (err, converted) {
+                    expect(err).to.not.be.ok;
+
+                    // remove `undefined` properties for testing
+                    converted = JSON.parse(JSON.stringify(converted));
+
+                    expect(converted).to.eql({
+                        id: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                        name: 'get-with-body',
+                        order: ['4f65e265-dd38-0a67-71a5-d9dd50fa37a1'],
+                        folders_order: [],
+                        folders: [],
+                        requests: [{
+                            id: '4f65e265-dd38-0a67-71a5-d9dd50fa37a1',
+                            name: '',
+                            collectionId: '84b2b626-d3a6-0f31-c7a0-47733c01d0c2',
+                            method: 'GET',
+                            headers: '',
+                            dataMode: 'raw',
+                            rawModeData: 'foo=bar',
+                            url: 'https://postman-echo.com/get',
+                            responses: [],
+                            pathVariableData: [],
+                            queryParams: [],
+                            headerData: []
+                        }],
+                        protocolProfileBehavior: {
+                            disableBodyPruning: true
+                        }
+                    });
+                    done();
+                });
+            });
+
+            it('should be converted at folder level', function (done) {
+                transformer.convert({
+                    info: {
+                        _postman_id: '969e90b1-0742-41b5-8602-e137d25274ac'
+                    },
+                    auth: { type: 'noauth' },
+                    item: [{
+                        _postman_id: 'a9832f4d-657c-4cd2-a5a4-7ddd6bc4948e',
+                        auth: { type: 'noauth' },
+                        item: [],
+                        protocolProfileBehavior: {
+                            disableBodyPruning: true
+                        }
+                    }]
+                }, options, function (err, converted) {
+                    expect(err).to.not.be.ok;
+
+                    // remove `undefined` properties for testing
+                    converted = JSON.parse(JSON.stringify(converted));
+
+                    expect(converted).to.eql({
+                        id: '969e90b1-0742-41b5-8602-e137d25274ac',
+                        folders: [{
+                            id: 'a9832f4d-657c-4cd2-a5a4-7ddd6bc4948e',
+                            auth: { type: 'noauth' },
+                            folders_order: [],
+                            order: [],
+                            protocolProfileBehavior: {
+                                disableBodyPruning: true
+                            }
+                        }],
+                        order: [],
+                        requests: [],
+                        folders_order: ['a9832f4d-657c-4cd2-a5a4-7ddd6bc4948e']
                     });
                     done();
                 });


### PR DESCRIPTION
`protocolProfileBehavior` is converted at `request` level only. The [doc](https://github.com/postmanlabs/postman-runtime/blob/develop/docs/protocol-profile-behavior.md) mentions it should be converted at all levels.