### PR TITLE
Fixed lost value of query params for params having `equals:false`

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+master:
+  bugs fixed:
+    - >-
+      GH-278 Fixed a bug where query param values are lost during v1 -> v2.x
+      conversions
+
 3.3.1:
   date: 2020-03-27
   bugs fixed:

--- a/lib/converters/v1.0.0/converter-v1-to-v2.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v2.js
@@ -131,8 +131,9 @@ _.assign(Builders.prototype, {
                     (queryParam.value === null) && (queryParam.value = '');
                 }
                 else {
-                    // = is not appended when the value is null
-                    queryParam.value = null;
+                    // = is not appended when the value is null. However,
+                    // non empty value should be preserved
+                    queryParam.value = queryParam.value || null;
                 }
 
                 queryParamAltered = true;

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -3361,6 +3361,40 @@ describe('v1.0.0 to v2.0.0', function () {
                 });
             });
         });
+
+        // [GitHub #8251, #8374]
+        it('should preserve param value when equals is false', function () {
+            transformer.convertSingle({
+                id: '0628a95f-c283-94e2-fa9f-53477775692f',
+                name: 'A world of foo!',
+                url: 'https://postman-echo.com/get?alpha=beta',
+                collectionId: '03cf74df-32de-af8b-7db8-855b51b05e50',
+                queryParams: [
+                    // param having `equals:false`
+                    { key: 'alpha', value: 'beta', equals: false }
+                ]
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    _postman_id: '0628a95f-c283-94e2-fa9f-53477775692f',
+                    name: 'A world of foo!',
+                    request: {
+                        header: [],
+                        url: {
+                            raw: 'https://postman-echo.com/get?alpha=beta',
+                            protocol: 'https',
+                            host: ['postman-echo', 'com'],
+                            path: ['get'],
+                            query: [
+                                // param value is preserved here
+                                { key: 'alpha', value: 'beta' }
+                            ]
+                        }
+                    },
+                    response: []
+                });
+            });
+        });
     });
 
     describe('retainIds', function () {

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -3430,6 +3430,40 @@ describe('v1.0.0 to v2.1.0', function () {
                 });
             });
         });
+
+        // [GitHub #8251, #8374]
+        it('should preserve param value when equals is false', function () {
+            transformer.convertSingle({
+                id: '0628a95f-c283-94e2-fa9f-53477775692f',
+                name: 'A world of foo!',
+                url: 'https://postman-echo.com/get?alpha=beta',
+                collectionId: '03cf74df-32de-af8b-7db8-855b51b05e50',
+                queryParams: [
+                    // param having `equals:false`
+                    { key: 'alpha', value: 'beta', equals: false }
+                ]
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    _postman_id: '0628a95f-c283-94e2-fa9f-53477775692f',
+                    name: 'A world of foo!',
+                    request: {
+                        header: [],
+                        url: {
+                            raw: 'https://postman-echo.com/get?alpha=beta',
+                            protocol: 'https',
+                            host: ['postman-echo', 'com'],
+                            path: ['get'],
+                            query: [
+                                // param value is preserved here
+                                { key: 'alpha', value: 'beta' }
+                            ]
+                        }
+                    },
+                    response: []
+                });
+            });
+        });
     });
 
     describe('retainIds', function () {


### PR DESCRIPTION
Query param values were being replaced with `null` for params having `equals: false`. This was causing unexpected behavior while sending requests from the Postman app as described in the following issues. That is fixed now and the values are preserved.

Issues:
- https://github.com/postmanlabs/postman-app-support/issues/8251
- https://github.com/postmanlabs/postman-app-support/issues/8374 