### PR TITLE
Fix response code type if v1 responseCode has invalid type

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,8 @@
+master:
+  fixed bugs:
+    - >-
+      Fixed a bug where response code type remained invalid after conversion
+      from v1 to v2.x
 4.1.2:
   date: 2021-04-15
   fixed bugs:

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,8 +1,9 @@
 master:
   fixed bugs:
     - >-
-      Fixed a bug where response code type remained invalid after conversion
-      from v1 to v2.x
+      GH-418 Fixed a bug where response code type remained invalid after
+      conversion from v1 to v2.x
+
 4.1.2:
   date: 2021-04-15
   fixed bugs:

--- a/lib/converters/v1.0.0/converter-v1-to-v2.js
+++ b/lib/converters/v1.0.0/converter-v1-to-v2.js
@@ -588,7 +588,7 @@ _.assign(Builders.prototype, {
         response.name = responseV1.name || 'response';
         response.originalRequest = originalRequest ? self.request(originalRequest) : undefined;
         response.status = responseV1.responseCode && responseV1.responseCode.name || undefined;
-        response.code = responseV1.responseCode && responseV1.responseCode.code || undefined;
+        response.code = responseV1.responseCode && Number(responseV1.responseCode.code) || undefined;
         response._postman_previewlanguage = responseV1.language;
         response._postman_previewtype = responseV1.previewType;
         response.header = responseV1.headers;

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -3945,4 +3945,112 @@ describe('v1.0.0 to v2.0.0', function () {
             });
         });
     });
+
+    describe('.covertResponse', function () {
+        it('should convert responses', function () {
+            transformer.convertResponse({
+                responseCode: { code: 200, name: 'OK' },
+                time: 412,
+                headers: [{
+                    key: 'Content-Type',
+                    value: 'text/html; charset=ISO-8859-1',
+                    name: 'Content-Type',
+                    description: 'The mime type of this content'
+                }],
+                cookies: [],
+                text: '<html></html>',
+                code: 200,
+                responseSize: {
+                    body: 14560,
+                    header: 669
+                },
+                mimeType: 'text',
+                fileName: 'response.html',
+                dataURI: 'data:text/html;base64, PGh0bWw+PC9odG1sPg==',
+                id: '21c40bcc-c1d5-1f91-06df-d7f4e66d1647',
+                name: 'Sample Response',
+                request: {
+                    url: 'https://foo.com',
+                    headers: [],
+                    data: 'akjshgdajhsgd',
+                    method: 'GET',
+                    dataMode: 'raw'
+                }
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    body: '<html></html>',
+                    code: 200,
+                    cookie: [],
+                    header: [{
+                        key: 'Content-Type',
+                        value: 'text/html; charset=ISO-8859-1',
+                        name: 'Content-Type',
+                        description: 'The mime type of this content'
+                    }],
+                    id: '21c40bcc-c1d5-1f91-06df-d7f4e66d1647',
+                    name: 'Sample Response',
+                    originalRequest: {
+                        body: { mode: 'raw', raw: 'akjshgdajhsgd' },
+                        header: [],
+                        method: 'GET',
+                        url: 'https://foo.com'
+                    },
+                    responseTime: 412,
+                    status: 'OK'
+                });
+            });
+        });
+
+        it('should convert responseCode to code and status', function () {
+            transformer.convertResponse({
+                responseCode: { code: '200', name: 'OK' },
+                id: '21c40bcc-c1d5-1f91-06df-d7f4e66d1647',
+                name: 'Sample Response',
+                request: {
+                    url: 'https://foo.com',
+                    method: 'GET'
+                }
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    id: '21c40bcc-c1d5-1f91-06df-d7f4e66d1647',
+                    name: 'Sample Response',
+                    code: 200,
+                    status: 'OK',
+                    cookie: [],
+                    originalRequest: {
+                        header: [],
+                        method: 'GET',
+                        url: 'https://foo.com'
+                    }
+                });
+            });
+        });
+
+        it('should drop code from responseCode if code is not number', function () {
+            transformer.convertResponse({
+                responseCode: { code: 'abc', name: 'OK' },
+                id: '21c40bcc-c1d5-1f91-06df-d7f4e66d1647',
+                name: 'Sample Response',
+                request: {
+                    url: 'https://foo.com',
+                    method: 'GET'
+                }
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    id: '21c40bcc-c1d5-1f91-06df-d7f4e66d1647',
+                    name: 'Sample Response',
+                    status: 'OK',
+                    cookie: [],
+                    originalRequest: {
+                        header: [],
+                        method: 'GET',
+                        url: 'https://foo.com'
+                    }
+                });
+            });
+        });
+    });
 });

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -4009,4 +4009,133 @@ describe('v1.0.0 to v2.1.0', function () {
             });
         });
     });
+
+    describe('.covertResponse', function () {
+        it('should convert responses', function () {
+            transformer.convertResponse({
+                responseCode: { code: 200, name: 'OK' },
+                time: 412,
+                headers: [{
+                    key: 'Content-Type',
+                    value: 'text/html; charset=ISO-8859-1',
+                    name: 'Content-Type',
+                    description: 'The mime type of this content'
+                }],
+                cookies: [],
+                text: '<html></html>',
+                code: 200,
+                responseSize: {
+                    body: 14560,
+                    header: 669
+                },
+                mimeType: 'text',
+                fileName: 'response.html',
+                dataURI: 'data:text/html;base64, PGh0bWw+PC9odG1sPg==',
+                id: '21c40bcc-c1d5-1f91-06df-d7f4e66d1647',
+                name: 'Sample Response',
+                request: {
+                    url: 'https://foo.com',
+                    headers: [],
+                    data: 'akjshgdajhsgd',
+                    method: 'GET',
+                    dataMode: 'raw'
+                }
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    body: '<html></html>',
+                    code: 200,
+                    cookie: [],
+                    header: [{
+                        key: 'Content-Type',
+                        value: 'text/html; charset=ISO-8859-1',
+                        name: 'Content-Type',
+                        description: 'The mime type of this content'
+                    }],
+                    id: '21c40bcc-c1d5-1f91-06df-d7f4e66d1647',
+                    name: 'Sample Response',
+                    originalRequest: {
+                        body: { mode: 'raw', raw: 'akjshgdajhsgd' },
+                        header: [],
+                        method: 'GET',
+                        url: {
+                            host: [
+                                'foo',
+                                'com'
+                            ],
+                            protocol: 'https',
+                            raw: 'https://foo.com'
+                        }
+                    },
+                    responseTime: 412,
+                    status: 'OK'
+                });
+            });
+        });
+
+        it('should convert responseCode to code and status', function () {
+            transformer.convertResponse({
+                responseCode: { code: '200', name: 'OK' },
+                id: '21c40bcc-c1d5-1f91-06df-d7f4e66d1647',
+                name: 'Sample Response',
+                request: {
+                    url: 'https://foo.com',
+                    method: 'GET'
+                }
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    id: '21c40bcc-c1d5-1f91-06df-d7f4e66d1647',
+                    name: 'Sample Response',
+                    code: 200,
+                    status: 'OK',
+                    cookie: [],
+                    originalRequest: {
+                        header: [],
+                        method: 'GET',
+                        url: {
+                            host: [
+                                'foo',
+                                'com'
+                            ],
+                            protocol: 'https',
+                            raw: 'https://foo.com'
+                        }
+                    }
+                });
+            });
+        });
+
+        it('should drop code from responseCode if code is not number', function () {
+            transformer.convertResponse({
+                responseCode: { code: 'abc', name: 'OK' },
+                id: '21c40bcc-c1d5-1f91-06df-d7f4e66d1647',
+                name: 'Sample Response',
+                request: {
+                    url: 'https://foo.com',
+                    method: 'GET'
+                }
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+                expect(JSON.parse(JSON.stringify(result))).to.eql({
+                    id: '21c40bcc-c1d5-1f91-06df-d7f4e66d1647',
+                    name: 'Sample Response',
+                    status: 'OK',
+                    cookie: [],
+                    originalRequest: {
+                        header: [],
+                        method: 'GET',
+                        url: {
+                            host: [
+                                'foo',
+                                'com'
+                            ],
+                            protocol: 'https',
+                            raw: 'https://foo.com'
+                        }
+                    }
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
While converting v1 to v2, there were some errors where invalid `responseCode.code` after conversion resulted in invalid `response.code` in v2.
This change tries to fix this issue while converting and if not possible, removes the invalid value.