### PR TITLE
Return undefined for certain keys in case of partial transformation

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+unreleased:
+  chores:
+    - GH-486 [Internal] Added new handlePartial option
+
 4.1.4:
   date: 2021-10-23
   fixed bugs:

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,6 @@
 unreleased:
   chores:
-    - GH-486 [Internal] Added new handlePartial option
+    - GH-486 [private] Added handlePartial option for v2.x -> v1 conversions
 
 4.1.4:
   date: 2021-10-23

--- a/lib/converters/v2.0.0/converter-v2-to-v1.js
+++ b/lib/converters/v2.0.0/converter-v2-to-v1.js
@@ -123,7 +123,7 @@ _.assign(Builders.prototype, {
      * @returns {*|string} - The resultant header string.
      */
     headers: function (item) {
-        if (!(item && item.request && (item.request.headers || item.request.header))) { return; }
+        if (!(item && item.request)) { return; }
 
         return _.map(item.request.headers || item.request.header, function (header) {
             return (header.disabled ? '// ' : '') + header.key + ': ' + header.value;
@@ -450,6 +450,7 @@ _.assign(Builders.prototype, {
             variables = self.variables(item, { retainIds: self.options.retainIds }),
             url = req && req.url,
             retainEmpty = self.options.retainEmptyValues,
+            handlePartial = self.options.handlePartialTransformation,
             urlObj = _.isString(url) ? util.urlparse(url) : url,
             headers = req && (req.headers || req.header),
             pathVariables = urlObj && (urlObj.variables || urlObj.variable);
@@ -511,7 +512,7 @@ _.assign(Builders.prototype, {
         });
 
         // description transformations for v2 to v1
-        urlObj && (request.pathVariableData = pathVariables && _.map(pathVariables, function (v) {
+        urlObj && (request.pathVariableData = (pathVariables || !handlePartial) && _.map(pathVariables, function (v) {
             var result = { key: v.key || v.id, value: v.value };
 
             // Prevent empty path variable descriptions from showing up in converted results, keeps collections clean.
@@ -521,7 +522,7 @@ _.assign(Builders.prototype, {
             return result;
         }) || undefined);
 
-        urlObj && (request.queryParams = urlObj.query && _.map(urlObj.query, function (queryParam) {
+        urlObj && (request.queryParams = (urlObj.query || !handlePartial) && _.map(urlObj.query, function (queryParam) {
             // Prevents empty query param descriptions from showing up in the result, keeps collections clean.
             queryParam.description = self.description(queryParam.description);
 
@@ -532,7 +533,7 @@ _.assign(Builders.prototype, {
         }) || undefined);
 
         // item truthiness is already validated by this point
-        item.request && (request.headerData = headers && _.map(headers, function (header) {
+        request.headerData = (headers || !handlePartial) && _.map(headers, function (header) {
             // Prevents empty query param descriptions from showing up in the result, keeps collections clean.
             header.description = self.description(header.description);
 
@@ -540,7 +541,11 @@ _.assign(Builders.prototype, {
             delete header.disabled;
 
             return header;
-        }) || undefined);
+        }) || undefined;
+
+        // In case of a partial transformation, if headers are not sent, then set the headers property in v1 to be
+        // undefined
+        (!headers && handlePartial) && (request.headers = undefined);
 
         return request;
     },

--- a/lib/converters/v2.0.0/converter-v2-to-v1.js
+++ b/lib/converters/v2.0.0/converter-v2-to-v1.js
@@ -123,7 +123,7 @@ _.assign(Builders.prototype, {
      * @returns {*|string} - The resultant header string.
      */
     headers: function (item) {
-        if (!(item && item.request)) { return; }
+        if (!(item && item.request && (item.request.headers || item.request.header))) { return; }
 
         return _.map(item.request.headers || item.request.header, function (header) {
             return (header.disabled ? '// ' : '') + header.key + ': ' + header.value;
@@ -509,7 +509,7 @@ _.assign(Builders.prototype, {
         });
 
         // description transformations for v2 to v1
-        urlObj && (request.pathVariableData = _.map(urlObj.variables || urlObj.variable, function (v) {
+        urlObj && (request.pathVariableData = (urlObj.variables || urlObj.variable) && _.map(urlObj.variables || urlObj.variable, function (v) {
             var result = { key: v.key || v.id, value: v.value };
 
             // Prevent empty path variable descriptions from showing up in converted results, keeps collections clean.
@@ -517,9 +517,9 @@ _.assign(Builders.prototype, {
             else if (retainEmpty) { result.description = null; }
 
             return result;
-        }));
+        }) || undefined);
 
-        urlObj && (request.queryParams = _.map(urlObj.query, function (queryParam) {
+        urlObj && (request.queryParams = urlObj.query && _.map(urlObj.query, function (queryParam) {
             // Prevents empty query param descriptions from showing up in the result, keeps collections clean.
             queryParam.description = self.description(queryParam.description);
 
@@ -527,10 +527,10 @@ _.assign(Builders.prototype, {
             delete queryParam.disabled;
 
             return queryParam;
-        }));
+        }) || undefined);
 
         // item truthiness is already validated by this point
-        request.headerData = _.map(item.request && (item.request.headers || item.request.header), function (header) {
+        item.request && (request.headerData = (item.request.headers || item.request.header) && _.map(item.request && (item.request.headers || item.request.header), function (header) {
             // Prevents empty query param descriptions from showing up in the result, keeps collections clean.
             header.description = self.description(header.description);
 
@@ -538,7 +538,7 @@ _.assign(Builders.prototype, {
             delete header.disabled;
 
             return header;
-        });
+        }) || undefined);
 
         return request;
     },

--- a/lib/converters/v2.0.0/converter-v2-to-v1.js
+++ b/lib/converters/v2.0.0/converter-v2-to-v1.js
@@ -450,7 +450,7 @@ _.assign(Builders.prototype, {
             variables = self.variables(item, { retainIds: self.options.retainIds }),
             url = req && req.url,
             retainEmpty = self.options.retainEmptyValues,
-            handlePartial = self.options.handlePartialTransformation,
+            handlePartial = self.options.handlePartial,
             urlObj = _.isString(url) ? util.urlparse(url) : url,
             headers = req && (req.headers || req.header),
             pathVariables = urlObj && (urlObj.variables || urlObj.variable);
@@ -512,7 +512,7 @@ _.assign(Builders.prototype, {
         });
 
         // description transformations for v2 to v1
-        urlObj && (request.pathVariableData = (pathVariables || !handlePartial) && _.map(pathVariables, function (v) {
+        urlObj && (request.pathVariableData = _.map(pathVariables, function (v) {
             var result = { key: v.key || v.id, value: v.value };
 
             // Prevent empty path variable descriptions from showing up in converted results, keeps collections clean.
@@ -520,9 +520,9 @@ _.assign(Builders.prototype, {
             else if (retainEmpty) { result.description = null; }
 
             return result;
-        }) || undefined);
+        }));
 
-        urlObj && (request.queryParams = (urlObj.query || !handlePartial) && _.map(urlObj.query, function (queryParam) {
+        urlObj && (request.queryParams = _.map(urlObj.query, function (queryParam) {
             // Prevents empty query param descriptions from showing up in the result, keeps collections clean.
             queryParam.description = self.description(queryParam.description);
 
@@ -530,10 +530,10 @@ _.assign(Builders.prototype, {
             delete queryParam.disabled;
 
             return queryParam;
-        }) || undefined);
+        }));
 
         // item truthiness is already validated by this point
-        request.headerData = (headers || !handlePartial) && _.map(headers, function (header) {
+        request.headerData = _.map(headers, function (header) {
             // Prevents empty query param descriptions from showing up in the result, keeps collections clean.
             header.description = self.description(header.description);
 
@@ -541,11 +541,14 @@ _.assign(Builders.prototype, {
             delete header.disabled;
 
             return header;
-        }) || undefined;
+        });
 
-        // In case of a partial transformation, if headers are not sent, then set the headers property in v1 to be
-        // undefined
-        (!headers && handlePartial) && (request.headers = undefined);
+        // In case of a partial transformation, remove undefined fields
+        if (handlePartial) {
+            (headers === undefined) && (request.headers = request.headerData = undefined);
+            (item.responses === undefined) && (request.responses = request.responses_order = undefined);
+            (url === undefined) && (request.url = request.pathVariableData = request.queryParams = undefined);
+        }
 
         return request;
     },

--- a/lib/converters/v2.0.0/converter-v2-to-v1.js
+++ b/lib/converters/v2.0.0/converter-v2-to-v1.js
@@ -356,6 +356,7 @@ _.assign(Builders.prototype, {
     response: function (responseV2) {
         var self = this,
             response = {},
+            handlePartial = self.options.handlePartial,
             id = responseV2.id || responseV2._postman_id,
             originalRequest = responseV2.originalRequest || responseV2.request;
 
@@ -387,6 +388,16 @@ _.assign(Builders.prototype, {
         response.cookies = _.map(responseV2.cookies || responseV2.cookie, self.cookie);
         response.text = responseV2.body;
         response.rawDataType = 'text';
+
+        if (handlePartial) {
+            (!(responseV2.code || responseV2.status)) && (response.responseCode = undefined);
+            (responseV2.cookies === undefined) && (response.cookies = undefined);
+            (responseV2.body === undefined) && (
+                response.rawDataType =
+                response.language =
+                response.previewType = undefined
+            );
+        }
 
         return response;
     },
@@ -796,6 +807,15 @@ module.exports = {
                 return callback(e, null);
             }
             throw e;
+        }
+
+        if (options && options.handlePartial) {
+            (!collection.item) && (
+                newCollection.requests =
+                newCollection.folders =
+                newCollection.folders_order =
+                newCollection.order = undefined
+            );
         }
 
         if (callback) {

--- a/lib/converters/v2.0.0/converter-v2-to-v1.js
+++ b/lib/converters/v2.0.0/converter-v2-to-v1.js
@@ -450,7 +450,9 @@ _.assign(Builders.prototype, {
             variables = self.variables(item, { retainIds: self.options.retainIds }),
             url = req && req.url,
             retainEmpty = self.options.retainEmptyValues,
-            urlObj = _.isString(url) ? util.urlparse(url) : url;
+            urlObj = _.isString(url) ? util.urlparse(url) : url,
+            headers = req && (req.headers || req.header),
+            pathVariables = urlObj && (urlObj.variables || urlObj.variable);
 
         if (!skipResponses) {
             units.push('responses');
@@ -509,7 +511,7 @@ _.assign(Builders.prototype, {
         });
 
         // description transformations for v2 to v1
-        urlObj && (request.pathVariableData = (urlObj.variables || urlObj.variable) && _.map(urlObj.variables || urlObj.variable, function (v) {
+        urlObj && (request.pathVariableData = pathVariables && _.map(pathVariables, function (v) {
             var result = { key: v.key || v.id, value: v.value };
 
             // Prevent empty path variable descriptions from showing up in converted results, keeps collections clean.
@@ -530,7 +532,7 @@ _.assign(Builders.prototype, {
         }) || undefined);
 
         // item truthiness is already validated by this point
-        item.request && (request.headerData = (item.request.headers || item.request.header) && _.map(item.request && (item.request.headers || item.request.header), function (header) {
+        item.request && (request.headerData = headers && _.map(headers, function (header) {
             // Prevents empty query param descriptions from showing up in the result, keeps collections clean.
             header.description = self.description(header.description);
 

--- a/test/unit/v2.0.0/converter-v2-to-v1.test.js
+++ b/test/unit/v2.0.0/converter-v2-to-v1.test.js
@@ -2343,4 +2343,28 @@ describe('v2.0.0 to v1.0.0', function () {
             });
         });
     });
+
+    describe('handlePartialTransformation', function () {
+        let options = {
+            handlePartialTransformation: true,
+            inputVersion: '2.0.0',
+            outputVersion: '1.0.0'
+        };
+
+        it('should return headers, pathVariables, queryParams as undefined in a partial transformation',
+            function (done) {
+                transformer.convertSingle({
+                    name: 'This is the new name'
+                }, options, function (err, converted) {
+                    expect(err).to.not.be.ok;
+
+                    expect(converted).to.be.ok;
+                    expect(converted.headers).to.eql(undefined);
+                    expect(converted.pathVariableData).to.eql(undefined);
+                    expect(converted.queryParams).to.eql(undefined);
+
+                    done();
+                });
+            });
+    });
 });

--- a/test/unit/v2.0.0/converter-v2-to-v1.test.js
+++ b/test/unit/v2.0.0/converter-v2-to-v1.test.js
@@ -2347,20 +2347,75 @@ describe('v2.0.0 to v1.0.0', function () {
     describe('handlePartial', function () {
         let options = {
             handlePartial: true,
+            retainIds: true,
             inputVersion: '2.0.0',
             outputVersion: '1.0.0'
         };
 
-        it('should drop defaults and empty fields', function () {
-            transformer.convertSingle({
-                id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
-                name: 'This is the new name'
+        it('should drop defaults and empty fields on .convert', function () {
+            transformer.convert({
+                info: {
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e'
+                }
             }, options, function (err, converted) {
                 expect(err).not.to.be.ok;
 
                 expect(JSON.parse(JSON.stringify(converted))).to.eql({
-                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
-                    name: 'This is the new name'
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e'
+                });
+            });
+        });
+
+        it('should drop defaults and empty fields on .convertSingle', function () {
+            transformer.convertSingle({
+                id: '9d123ce5-314a-40cd-9852-6a8569513f4e'
+            }, options, function (err, converted) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(converted))).to.eql({
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e'
+                });
+            });
+        });
+
+        it('should drop defaults and empty fields on .convertResponse', function () {
+            transformer.convertResponse({
+                id: '9d123ce5-314a-40cd-9852-6a8569513f4e'
+            }, options, function (err, converted) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(converted))).to.eql({
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e'
+                });
+            });
+        });
+
+        it('should handle partial collection object', function () {
+            transformer.convert({
+                info: {
+                    id: 'C1'
+                },
+                item: [{
+                    id: 'R1',
+                    request: {
+                        url: ''
+                    }
+                }]
+            }, options, function (err, converted) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(converted))).to.eql({
+                    id: 'C1',
+                    order: ['R1'],
+                    folders_order: [],
+                    folders: [],
+                    requests: [{
+                        id: 'R1',
+                        collectionId: 'C1',
+                        url: '',
+                        pathVariableData: [],
+                        queryParams: []
+                    }]
                 });
             });
         });

--- a/test/unit/v2.0.0/converter-v2-to-v1.test.js
+++ b/test/unit/v2.0.0/converter-v2-to-v1.test.js
@@ -2344,27 +2344,69 @@ describe('v2.0.0 to v1.0.0', function () {
         });
     });
 
-    describe('handlePartialTransformation', function () {
+    describe('handlePartial', function () {
         let options = {
-            handlePartialTransformation: true,
+            handlePartial: true,
             inputVersion: '2.0.0',
             outputVersion: '1.0.0'
         };
 
-        it('should return headers, pathVariables, queryParams as undefined in a partial transformation',
-            function (done) {
-                transformer.convertSingle({
+        it('should drop defaults and empty fields', function () {
+            transformer.convertSingle({
+                id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                name: 'This is the new name'
+            }, options, function (err, converted) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(converted))).to.eql({
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
                     name: 'This is the new name'
-                }, options, function (err, converted) {
-                    expect(err).to.not.be.ok;
-
-                    expect(converted).to.be.ok;
-                    expect(converted.headers).to.eql(undefined);
-                    expect(converted.pathVariableData).to.eql(undefined);
-                    expect(converted.queryParams).to.eql(undefined);
-
-                    done();
                 });
             });
+        });
+
+        it('should handle partial request object', function () {
+            transformer.convertSingle({
+                id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                request: {
+                    url: 'https://example.com'
+                }
+            }, options, function (err, converted) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(converted))).to.eql({
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                    url: 'https://example.com',
+                    queryParams: [],
+                    pathVariableData: []
+                });
+            });
+        });
+
+        it('should retain empty properties', function () {
+            transformer.convertSingle({
+                id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                name: 'This is the new name',
+                request: {
+                    url: {},
+                    header: []
+                },
+                responses: []
+            }, options, function (err, converted) {
+                expect(err).not.to.be.ok;
+
+                expect(JSON.parse(JSON.stringify(converted))).to.eql({
+                    id: '9d123ce5-314a-40cd-9852-6a8569513f4e',
+                    name: 'This is the new name',
+                    url: '',
+                    queryParams: [],
+                    pathVariableData: [],
+                    headers: '',
+                    headerData: [],
+                    responses: [],
+                    responses_order: []
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
We have a use case to convert a partial element (collection, folder, request, response) from v2 to v1. Partial, in this case, means that we won't be having all the keys that represent an element, but only a subset of it.

Currently, the transformer returns all the keys after transformation (even the ones that were not sent as input) as undefined, but some of them are sent as empty arrays or empty strings which could potentially cause trouble in differentiating between an actual empty value vs. a default empty value.