### PR TITLE
Preserve `enabled` key for collection variables in v1 normalizer iff it is present and is false

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -86,6 +86,7 @@ module.exports = {
 
                 item.type && (result.type = item.type === 'text' ? 'string' : item.type);
                 item.disabled && (result.disabled = true);
+                _.has(item, 'enabled') && (item.enabled === false) && (result.enabled = false);
 
                 if (item.description) { result.description = item.description; }
                 else if (retainEmpty) { result.description = null; }


### PR DESCRIPTION
Preserve `enabled` key for collection variables in v1 normalizer iff it is present and is false.
This is being done to fix enabled/disabled info getting lost in normalize operation.
Note: As with disabled, we preserve the enabled field only when it indicates variable is not active.