### PR TITLE
Fix ppb flags missing in `requestObject` of responses

### DIFF
--- a/lib/converters/v2.0.0/converter-v2-to-v1.js
+++ b/lib/converters/v2.0.0/converter-v2-to-v1.js
@@ -351,9 +351,10 @@ _.assign(Builders.prototype, {
      * Converts a V2 response object to a V1 response
      *
      * @param {Object} responseV2 - The v2 response to be converted.
+     * @param {Object} item - The v2 item to extract saved responses from.
      * @returns {Object} - The converted v1 response.
      */
-    response: function (responseV2) {
+    response: function (responseV2, item) {
         var self = this,
             response = {},
             handlePartial = self.options.handlePartial,
@@ -362,6 +363,9 @@ _.assign(Builders.prototype, {
 
         // the true in the next line ensures that we don't recursively go on processing responses in a request.
         response.request = originalRequest ? self.request({ request: originalRequest }, undefined, true) : undefined;
+
+        // add protocolProfileBehavior property from item to the requestObject in the response
+        item && response.request && util.addProtocolProfileBehavior(item, response.request);
 
         // add the requestObject to the response (needed by sync)
         try {


### PR DESCRIPTION
Fixes issue where request body of examples which have `head` or `get` method get removed. This is because the requestObject in the response does not have the `disableBodyPruning` flag in the `protocolProfileBehaviour` (ppb).

Ref: https://github.com/postmanlabs/postman-app-support/issues/10900

---

- [ ] tests
- [ ] changelog