### PR TITLE
[CUE-3798] Adding transformation option for resettable fields

### DIFF
--- a/lib/converters/v2.0.0/converter-v2-to-v1.js
+++ b/lib/converters/v2.0.0/converter-v2-to-v1.js
@@ -15,7 +15,7 @@ _.assign(Builders.prototype, {
      *
      * @param {Object} entityV2  - The v1 auth manifest to be transformed into v1.
      * @param {?Object} options - The set of options for the current auth cleansing operation.
-     * @param {?Boolean} [options.includeNoauth=false] - When set to true, noauth is set to null.
+     * @param {?Boolean} [options.excludeNoauth=false] - When set to true, noauth is set to null.
      *
      * @returns {Object} The transformed auth object.
      */
@@ -463,6 +463,8 @@ _.assign(Builders.prototype, {
             variables = self.variables(item, { retainIds: self.options.retainIds }),
             url = req && req.url,
             retainEmpty = self.options.retainEmptyValues,
+            allowAuthReset = _.get(self.options, 'allowFieldResets', []).includes('auth'),
+            allowDescriptionReset = _.get(self.options, 'allowFieldResets', []).includes('description'),
             handlePartial = self.options.handlePartial,
             urlObj = _.isString(url) ? util.urlparse(url) : url,
             headers = req && (req.headers || req.header),
@@ -514,9 +516,11 @@ _.assign(Builders.prototype, {
 
         // Prevent empty request descriptions from showing up in the converted result, keeps collections clean.
         if (description) { request.description = description; }
-        else if (retainEmpty) { request.description = null; }
+        else if (retainEmpty || allowDescriptionReset && item.request.description === null) { request.description = null; }
 
-        (auth || (auth === null)) && (request.auth = auth);
+        if(allowAuthReset && auth === null){
+            request.auth = null;
+        } else (auth || (auth === null)) && (request.auth = auth);
         events && events.length && (request.events = events);
         variables && variables.length && (request.variables = variables);
 
@@ -691,11 +695,16 @@ _.assign(Builders.prototype, {
     description: function (descriptionV2) {
         var description,
             retainEmpty = this.options.retainEmptyValues;
+            allowReset = _.get(this.options, 'allowFieldResets', []).includes('description')
 
         description = _.isObject(descriptionV2) ? descriptionV2.content : descriptionV2;
 
-        if (description) { return description; }
-        else if (retainEmpty) { return null; }
+        if (description) {
+            return description;
+        } else if (retainEmpty || (allowReset && descriptionV2 === null)) {
+            return null;
+        }
+        
     }
 });
 

--- a/lib/converters/v2.1.0/converter-v21-to-v1.js
+++ b/lib/converters/v2.1.0/converter-v21-to-v1.js
@@ -98,6 +98,7 @@ module.exports = {
             varOpts = options && { fallback: options.env, retainIds: options.retainIds },
             id = _.get(collection, 'info._postman_id') || _.get(collection, 'info.id'),
             info = collection && collection.info,
+            allowAuthReset = _.get(options, 'allowFieldResets', []).includes('auth'),
             newCollection = {
                 id: id && options && options.retainIds ? id : util.uid(),
                 name: info && info.name
@@ -108,7 +109,9 @@ module.exports = {
         try {
             // eslint-disable-next-line max-len
             newCollection.description = builders.description(info && info.description);
-            (auth = builders.auth(collection, authOptions)) && (newCollection.auth = auth);
+            if(allowAuthReset && builders.auth(collection, authOptions) === null){
+                newCollection.auth = builders.auth(collection, authOptions)   
+            } else (auth = builders.auth(collection, authOptions)) && (newCollection.auth = auth);
             (events = builders.events(collection)) && (newCollection.events = events);
             (variables = builders.variables(collection, varOpts)) && (newCollection.variables = variables);
             util.addProtocolProfileBehavior(collection, newCollection);


### PR DESCRIPTION
## Description

Added a transformation option called `allowFieldResets` to denote an array of fields that can be reset during a patch/update

The following fields when reset to null during a merge were omitted during the patch operation. 

```Collection: auth,description```
```Request: auth,description```


[RCA](https://postmanlabs.atlassian.net/wiki/spaces/VC/pages/4491152723/CUE-3798+Fields+omitted+during+merge)

Fixes # (issue)

[JIRA](https://postmanlabs.atlassian.net/browse/CUE-3798)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested? (Add Screenshots, If applicable)

Tested on beta and matrix

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
