### PR TITLE
Added "secret" and "source" property support within variable.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -86,6 +86,8 @@ module.exports = {
 
                 item.type && (result.type = item.type === 'text' ? 'string' : item.type);
                 item.disabled && (result.disabled = true);
+                item.secret && (result.secret = true);
+                item.source && (result.source = item.source);
 
                 if (item.description) { result.description = item.description; }
                 else if (retainEmpty) { result.description = null; }

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -74,6 +74,60 @@ describe('util', function () {
 
             expect(processed[0]).to.have.property('id');
         });
+
+        it('should preserve secret property when set to true', function () {
+            const entity = {
+                    variables: [
+                        { key: 'password', value: 'secret123', secret: true }
+                    ]
+                },
+                processed = util.handleVars(entity, { noDefaults: true });
+
+            expect(processed[0]).to.have.property('secret', true);
+        });
+
+        it('should not include secret property when not present', function () {
+            const entity = {
+                    variables: [
+                        { key: 'name', value: 'John' }
+                    ]
+                },
+                processed = util.handleVars(entity, { noDefaults: true });
+
+            expect(processed[0]).to.not.have.property('secret');
+        });
+
+        it('should preserve source property when present', function () {
+            const source = {
+                    provider: 'postman',
+                    postman: {
+                        type: 'local',
+                        secretId: '123',
+                        vaultId: '456'
+                    }
+                },
+                entity = {
+                    variables: [
+                        { key: 'apiKey', value: '', secret: true, source: source }
+                    ]
+                },
+                processed = util.handleVars(entity, { noDefaults: true });
+
+            expect(processed[0]).to.have.property('secret', true);
+            expect(processed[0]).to.have.property('source');
+            expect(processed[0].source).to.deep.eql(source);
+        });
+
+        it('should not include source property when not present', function () {
+            const entity = {
+                    variables: [
+                        { key: 'name', value: 'John' }
+                    ]
+                },
+                processed = util.handleVars(entity, { noDefaults: true });
+
+            expect(processed[0]).to.not.have.property('source');
+        });
     });
 
     describe('sanitizeAuthArray', function () {

--- a/test/unit/v1.0.0/converter-v1-to-v2.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v2.test.js
@@ -3371,6 +3371,31 @@ describe('v1.0.0 to v2.0.0', function () {
                 done();
             });
         });
+
+        it('should preserve secret and source properties on variables', function (done) {
+            transformer.convert({
+                id: '2509a94e-eca1-43ca-a8aa-0e200636764f',
+                variables: [{
+                    id: 'var-1', key: 'apiKey', value: '', secret: true,
+                    source: { provider: 'postman', postman: { type: 'local', secretId: '123', vaultId: '456' } }
+                }, {
+                    id: 'var-2', key: 'name', value: 'John'
+                }]
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+
+                expect(result.variable[0]).to.include({ key: 'apiKey', secret: true });
+                expect(result.variable[0].source).to.eql({
+                    provider: 'postman',
+                    postman: { type: 'local', secretId: '123', vaultId: '456' }
+                });
+
+                expect(result.variable[1]).to.include({ key: 'name' });
+                expect(result.variable[1]).to.not.have.property('secret');
+                expect(result.variable[1]).to.not.have.property('source');
+                done();
+            });
+        });
     });
 
     describe('query parameters', function () {

--- a/test/unit/v1.0.0/converter-v1-to-v21.test.js
+++ b/test/unit/v1.0.0/converter-v1-to-v21.test.js
@@ -3524,6 +3524,31 @@ describe('v1.0.0 to v2.1.0', function () {
                 done();
             });
         });
+
+        it('should preserve secret and source properties on variables', function (done) {
+            transformer.convert({
+                id: '2509a94e-eca1-43ca-a8aa-0e200636764f',
+                variables: [{
+                    id: 'var-1', key: 'apiKey', value: '', secret: true,
+                    source: { provider: 'postman', postman: { type: 'local', secretId: '123', vaultId: '456' } }
+                }, {
+                    id: 'var-2', key: 'name', value: 'John'
+                }]
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+
+                expect(result.variable[0]).to.include({ key: 'apiKey', secret: true });
+                expect(result.variable[0].source).to.eql({
+                    provider: 'postman',
+                    postman: { type: 'local', secretId: '123', vaultId: '456' }
+                });
+
+                expect(result.variable[1]).to.include({ key: 'name' });
+                expect(result.variable[1]).to.not.have.property('secret');
+                expect(result.variable[1]).to.not.have.property('source');
+                done();
+            });
+        });
     });
 
     describe('query parameters', function () {

--- a/test/unit/v2.0.0/converter-v2-to-v1.test.js
+++ b/test/unit/v2.0.0/converter-v2-to-v1.test.js
@@ -310,6 +310,35 @@ describe('v2.0.0 to v1.0.0', function () {
                 });
             });
         });
+
+        it('should preserve secret and source properties on collection variables', function (done) {
+            transformer.convert({
+                info: {
+                    _postman_id: 'C1',
+                    schema: 'https://schema.getpostman.com/json/collection/v2.0.0/collection.json'
+                },
+                variable: [{
+                    id: 'var-1', key: 'apiKey', value: '', secret: true,
+                    source: { provider: 'azure', azure: { secretId: 'my-secret' } }
+                }, {
+                    id: 'var-2', key: 'name', value: 'John'
+                }],
+                item: []
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+
+                expect(result.variables[0]).to.include({ key: 'apiKey', secret: true });
+                expect(result.variables[0].source).to.eql({
+                    provider: 'azure',
+                    azure: { secretId: 'my-secret' }
+                });
+
+                expect(result.variables[1]).to.include({ key: 'name' });
+                expect(result.variables[1]).to.not.have.property('secret');
+                expect(result.variables[1]).to.not.have.property('source');
+                done();
+            });
+        });
     });
 
     describe('descriptions', function () {

--- a/test/unit/v2.1.0/converter-v21-to-v1.test.js
+++ b/test/unit/v2.1.0/converter-v21-to-v1.test.js
@@ -210,6 +210,35 @@ describe('v2.1.0 to v1.0.0', function () {
                 });
             });
         });
+
+        it('should preserve secret and source properties on collection variables', function (done) {
+            transformer.convert({
+                info: {
+                    _postman_id: 'C1',
+                    schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+                },
+                variable: [{
+                    id: 'var-1', key: 'apiKey', value: '', secret: true,
+                    source: { provider: 'azure', azure: { secretId: 'my-secret' } }
+                }, {
+                    id: 'var-2', key: 'name', value: 'John'
+                }],
+                item: []
+            }, options, function (err, result) {
+                expect(err).to.not.be.ok;
+
+                expect(result.variables[0]).to.include({ key: 'apiKey', secret: true });
+                expect(result.variables[0].source).to.eql({
+                    provider: 'azure',
+                    azure: { secretId: 'my-secret' }
+                });
+
+                expect(result.variables[1]).to.include({ key: 'name' });
+                expect(result.variables[1]).to.not.have.property('secret');
+                expect(result.variables[1]).to.not.have.property('source');
+                done();
+            });
+        });
     });
 
     describe('descriptions', function () {


### PR DESCRIPTION
## Overview

This PR adds support for maintaining the `secret` and `source` properties while transforming from v1 <> v2. This changes is based on the changes done below in postman-collection :

- https://github.com/postmanlabs/postman-collection/pull/1421
- https://github.com/postmanlabs/postman-collection/pull/1422